### PR TITLE
Remove broken libcurl3 import

### DIFF
--- a/backend/typescript/Dockerfile
+++ b/backend/typescript/Dockerfile
@@ -4,9 +4,6 @@ WORKDIR /app
 
 COPY package.json yarn.lock tsconfig.json ./
 
-# libcurl3 is required for mongodb-memory-server, which is used for testing
-RUN apt-get update && apt-get install -y libcurl3
-
 RUN yarn install
 
 COPY . ./


### PR DESCRIPTION
## Implementation description
Removes the `libcurl3` import.  It wasn't being used by our site, and the import was preventing new devs from setting up their environment.

## Steps to test
1. Delete the backend folder and any existing Docker volumes
2. Run the backend 
3. If it doesn't break, everything is working

