### PR TITLE
Token auth setup

### DIFF
--- a/backend/typescript/Dockerfile
+++ b/backend/typescript/Dockerfile
@@ -4,9 +4,6 @@ WORKDIR /app
 
 COPY package.json yarn.lock tsconfig.json ./
 
-# libcurl3 is required for mongodb-memory-server, which is used for testing
-RUN apt-get update && apt-get install -y libcurl3
-
 RUN yarn install
 
 COPY . ./

--- a/backend/typescript/graphql/resolvers/authResolvers.ts
+++ b/backend/typescript/graphql/resolvers/authResolvers.ts
@@ -43,12 +43,16 @@ const authResolvers = {
   Query: {
     isAuthorizedByRole: async (
       _parent: undefined,
-      { accessToken, roles }: {accessToken: string, roles: Role[] }): Promise<Boolean> => {
-        const Logger = logger(__filename);
-        Logger.error(`foo bar baz ${roles} ${accessToken}`)
-        const isAuthorized = await authService.isAuthorizedByRole(accessToken, new Set(roles))
-        return isAuthorized
-      },
+      { accessToken, roles }: { accessToken: string; roles: Role[] },
+    ): Promise<boolean> => {
+      const Logger = logger(__filename);
+      Logger.error(`foo bar baz ${roles} ${accessToken}`);
+      const isAuthorized = await authService.isAuthorizedByRole(
+        accessToken,
+        new Set(roles),
+      );
+      return isAuthorized;
+    },
   },
   Mutation: {
     login: async (

--- a/backend/typescript/graphql/types/authType.ts
+++ b/backend/typescript/graphql/types/authType.ts
@@ -25,9 +25,8 @@ const authType = gql`
   extend type Query {
     login(email: String!, password: String!): loginOK!
     isAuthorizedByRole(accessToken: String!, roles: [Role!]!): Boolean!
-
   }
-  
+
   extend type Mutation {
     login(email: String!, password: String!): AuthDTO!
     loginWithGoogle(idToken: String!): AuthDTO!

--- a/backend/typescript/graphql/types/authType.ts
+++ b/backend/typescript/graphql/types/authType.ts
@@ -8,6 +8,7 @@ const authType = gql`
     email: String!
     role: Role!
     accessToken: String!
+    refreshToken: String!
   }
 
   type loginOK {
@@ -23,8 +24,10 @@ const authType = gql`
 
   extend type Query {
     login(email: String!, password: String!): loginOK!
-  }
+    isAuthorizedByRole(accessToken: String!, roles: [Role!]!): Boolean!
 
+  }
+  
   extend type Mutation {
     login(email: String!, password: String!): AuthDTO!
     loginWithGoogle(idToken: String!): AuthDTO!

--- a/backend/typescript/models/user.model.ts
+++ b/backend/typescript/models/user.model.ts
@@ -15,7 +15,7 @@ export default class User extends Model {
   @Column({ type: DataType.STRING })
   auth_id!: string;
 
-  @Column({ type: DataType.INTEGER, primaryKey: true })
+  @Column({ type: DataType.INTEGER, primaryKey: true, autoIncrement: true })
   id!: number;
 
   @Column({ type: DataType.ENUM("User", "Admin") })

--- a/backend/typescript/services/implementations/authService.ts
+++ b/backend/typescript/services/implementations/authService.ts
@@ -178,7 +178,7 @@ class AuthService implements IAuthService {
         .auth()
         .getUser(decodedIdToken.uid);
 
-      return roles.has(userRole);
+      return firebaseUser.emailVerified && roles.has(userRole);
     } catch (error) {
       return false;
     }

--- a/backend/typescript/services/implementations/authService.ts
+++ b/backend/typescript/services/implementations/authService.ts
@@ -174,12 +174,11 @@ class AuthService implements IAuthService {
       const userRole = await this.userService.getUserRoleByAuthId(
         decodedIdToken.uid,
       );
-
       const firebaseUser = await firebaseAdmin
         .auth()
         .getUser(decodedIdToken.uid);
 
-      return firebaseUser.emailVerified && roles.has(userRole);
+      return roles.has(userRole);
     } catch (error) {
       return false;
     }

--- a/backend/typescript/services/implementations/userService.ts
+++ b/backend/typescript/services/implementations/userService.ts
@@ -170,6 +170,7 @@ class UserService implements IUserService {
           first_name: user.firstName,
           last_name: user.lastName,
           auth_id: firebaseUser.uid,
+          email: firebaseUser.email,
           role: user.role,
         });
       } catch (postgresError) {


### PR DESCRIPTION
## Notion ticket link
<!-- Please replace with your ticket's URL -->
[[FE] Dashboard - Authentication & Saving Token](https://www.notion.so/uwblueprintexecs/FE-Dashboard-Authentication-Saving-Token-f537cc9fb44c4c0e92df387635475317)


<!-- Give a quick summary of the implementation details, provide design justifications if necessary -->
## Implementation description
* Added backend IsAuthorizedByRole route for verifying a user role using their refresh token.


<!-- What should the reviewer do to verify your changes? Describe expected results and include screenshots when appropriate -->
## Steps to test
1. Test isAuthorizedByRole with the following body on endpoint `http://localhost:5000/graphql`
```
query isAuthorizedByRole{
    isAuthorizedByRole(accessToken: <YOUR_ACCESS_TOKEN>, roles: <ROLES>)
}
```
For example:

```
query isAuthorizedByRole{
    isAuthorizedByRole(accessToken: "eyJhbGciOiJSUzI1NiIsImtpZCI6IjU0NWUyNDZjNTEwNmExMGQ2MzFiMTA0M2E3MWJiNTllNWJhMGM5NGQiLCJ0eXAiOiJKV1QifQ.eyJpc3MiOiJodHRwczovL3NlY3VyZXRva2VuLmdvb2dsZS5jb20vdXctYmx1ZXByaW50IiwiYXVkIjoidXctYmx1ZXByaW50IiwiYXV0aF90aW1lIjoxNjg1NjY3MDY5LCJ1c2VyX2lkIjoiOG5MZDgwellhT1hHSXlMQUY2OU1TSmdqZGIyMiIsInN1YiI6IjhuTGQ4MHpZYU9YR0l5TEFGNjlNU0pnamRiMjIiLCJpYXQiOjE2ODU2NjcwNjksImV4cCI6MTY4NTY3MDY2OSwiZW1haWwiOiJ0aG9tYXMud3U5MzFAZ21haWwuY29tIiwiZW1haWxfdmVyaWZpZWQiOnRydWUsImZpcmViYXNlIjp7ImlkZW50aXRpZXMiOnsiZW1haWwiOlsidGhvbWFzLnd1OTMxQGdtYWlsLmNvbSJdfSwic2lnbl9pbl9wcm92aWRlciI6InBhc3N3b3JkIn19.vU5IY8LtVxxOUB-7a8_VwxigLoX-Feq1JoW6CSqCbA-f3odg9kPySl2RHTl6uobsUDhXzE-tSRWhtvpeAnWwOm1p_h3P6DQnAs6o9LlFJZAJjq9f9k0zJgPUBBa56ber72L7viA3lMGsCc3nagL08VXwD0gyfssy4P4wLYODP6uubOL8WyIcLWrWa4l3d9Fdcdejcft4uDYpbvcqnpGnhObMizlNYxjfYkcpjJLm4z4b-hns6UIJkXaHxxLZpaWdIiUpn_EPJS2PnsKJSyiCFPFwMwpNCpdjIW873c7vw9b_g9-XWFxlSBTVXsRy3mZrc3ycYPEXrxXaf6ekjJCwIg", roles: [Admin])
}
```


<!-- Draw attention to the substantial parts of your PR or anything you'd like a second opinion on -->
## What should reviewers focus on?
* Unsure of how I'm handling the transfer of data from frontend to GraphQl to typescript. Both the frontend, backend, and GraphQl have their own unique definitions of the Roles object (Which is either "Admin" or "User"). Maybe we can unify the definitions to come from one, singular source.
* All of the existing implementation features aren't "complete". We still need to create middleware which automatically refreshes the access token if it is expired and update isAuthorizedByRole to try. We also need to edit all endpoints which accept an accessToken to also accept a refreshToken because of the previous sentence. 


## Checklist
- [x] My PR name is descriptive and in imperative tense
- [x] My commit messages are descriptive and in imperative tense. My commits are atomic and trivial commits are squashed or fixup'd into non-trivial commits
- [x] I have run the appropriate linter(s)
- [x] I have requested a review from the PL, as well as other devs who have background knowledge on this PR or who will be building on top of this PR
