### PR TITLE
Add bulk update method to application dashboard API

### DIFF
--- a/backend/typescript/graphql/index.ts
+++ b/backend/typescript/graphql/index.ts
@@ -79,6 +79,7 @@ const graphQLMiddlewares = {
     deleteSimpleEntity: authorizedByAllRoles(),
     changeRating: authorizedByAllRoles(),
     changeSkillCategory: authorizedByAllRoles(),
+    updateApplications: authorizedByAllRoles(),
     createUser: authorizedByAdmin(),
     updateUser: authorizedByAdmin(),
     deleteUserById: authorizedByAdmin(),

--- a/backend/typescript/graphql/resolvers/dashboardResolvers.ts
+++ b/backend/typescript/graphql/resolvers/dashboardResolvers.ts
@@ -1,6 +1,6 @@
 import AppDashboardService from "../../services/implementations/appDashboardService";
 import IAppDashboardService from "../../services/interfaces/appDashboardService";
-import { ApplicationDashboardDTO, ApplicationDTO } from "../../types";
+import { ApplicationDashboardDTO, ApplicationDTO, ApplicationDashboardInput } from "../../types";
 
 const dashboardService: IAppDashboardService = new AppDashboardService();
 
@@ -54,6 +54,12 @@ const dashboardResolvers = {
     ): Promise<ApplicationDashboardDTO> => {
       const dashboard = dashboardService.mutateSkillCategory(id, newValue);
       return dashboard;
+    },
+    updateApplications: async (
+      _parent: undefined,
+      {applications }: {applications: Array<ApplicationDashboardInput>},
+    ): Promise<Array<number>> => {
+      return dashboardService.updateBulkApplications(applications);
     },
   },
 };

--- a/backend/typescript/graphql/resolvers/dashboardResolvers.ts
+++ b/backend/typescript/graphql/resolvers/dashboardResolvers.ts
@@ -1,6 +1,10 @@
 import AppDashboardService from "../../services/implementations/appDashboardService";
 import IAppDashboardService from "../../services/interfaces/appDashboardService";
-import { ApplicationDashboardDTO, ApplicationDTO, ApplicationDashboardInput } from "../../types";
+import {
+  ApplicationDashboardDTO,
+  ApplicationDTO,
+  ApplicationDashboardInput,
+} from "../../types";
 
 const dashboardService: IAppDashboardService = new AppDashboardService();
 
@@ -57,7 +61,7 @@ const dashboardResolvers = {
     },
     updateApplications: async (
       _parent: undefined,
-      {applications }: {applications: Array<ApplicationDashboardInput>},
+      { applications }: { applications: Array<ApplicationDashboardInput> },
     ): Promise<Array<number>> => {
       return dashboardService.updateBulkApplications(applications);
     },

--- a/backend/typescript/graphql/types/dashboardType.ts
+++ b/backend/typescript/graphql/types/dashboardType.ts
@@ -13,6 +13,17 @@ const dashboardType = gql`
     applicationId: Int!
   }
 
+  input ApplicationDashboardInput {
+    id: Int!
+    reviewerEmail: String
+    passionFSG: Int
+    teamPlayer: Int
+    desireToLearn: Int
+    skill: Int
+    skillCategory: String
+    reviewerId: Int
+  }
+
   type ApplicationDTO {
     id: Int!
     academicYear: String
@@ -62,9 +73,8 @@ const dashboardType = gql`
       newValue: Int!
     ): ApplicationDashboardDTO!
     changeSkillCategory(id: Int!, newValue: String!): ApplicationDashboardDTO!
+    updateApplications(applications: [ApplicationDashboardInput]!): [Int]!
   }
 `;
 
 export default dashboardType;
-
-// changeSkillCategory(id: Int!, newValue: String!): ApplicationDashboardDTO!

--- a/backend/typescript/services/implementations/appDashboardService.ts
+++ b/backend/typescript/services/implementations/appDashboardService.ts
@@ -203,6 +203,29 @@ class AppDashboardService implements IAppDashboardService {
       applicationId: dashboard.applicationId,
     };
   }
+
+  async updateBulkApplications(applicationData: Array<Partial<ApplicationDashboardDTO>>): Promise<Array<number>> {
+    let res: number[] = [];
+    await Promise.all(applicationData.map(update => {
+      const { id, ...values } = update;
+      if (id !== undefined && id ) {
+        res.push(id);
+      }
+
+      ApplicationDashboardTable.update(
+        values,
+        { where: { id }, returning: true }
+      ).catch((err: Error) => {
+        Logger.error("Error in application dashboard batch update: " + err.toString());
+        throw err;
+      });
+    })).catch(err => {
+      Logger.error("Failed application dashboard batch update");
+      throw err;
+    });
+
+    return res;
+  }
 }
 
 export default AppDashboardService;

--- a/backend/typescript/services/implementations/appDashboardService.ts
+++ b/backend/typescript/services/implementations/appDashboardService.ts
@@ -204,22 +204,29 @@ class AppDashboardService implements IAppDashboardService {
     };
   }
 
-  async updateBulkApplications(applicationData: Array<Partial<ApplicationDashboardDTO>>): Promise<Array<number>> {
-    let res: number[] = [];
-    await Promise.all(applicationData.map(update => {
-      const { id, ...values } = update;
-      if (id !== undefined && id ) {
-        res.push(id);
-      }
+  async updateBulkApplications(
+    applicationData: Array<Partial<ApplicationDashboardDTO>>,
+  ): Promise<Array<number>> {
+    const res: number[] = [];
+    await Promise.all(
+      applicationData.map((update) => {
+        const { id, ...values } = update;
+        if (id !== undefined && id) {
+          res.push(id);
+        }
 
-      ApplicationDashboardTable.update(
-        values,
-        { where: { id }, returning: true }
-      ).catch((err: Error) => {
-        Logger.error("Error in application dashboard batch update: " + err.toString());
-        throw err;
-      });
-    })).catch(err => {
+        ApplicationDashboardTable.update(values, {
+          where: { id },
+          returning: true,
+        }).catch((err: Error) => {
+          Logger.error(
+            `Error in application dashboard batch update: ${err.toString()}`,
+          );
+          throw err;
+        });
+        return id;
+      }),
+    ).catch((err) => {
       Logger.error("Failed application dashboard batch update");
       throw err;
     });

--- a/backend/typescript/services/interfaces/appDashboardService.ts
+++ b/backend/typescript/services/interfaces/appDashboardService.ts
@@ -18,13 +18,13 @@ interface IAppDashboardService {
 
   /**
    * Bulk updates applications in reviewer dashboard
-   * @param applicationData 
+   * @param applicationData
    * @returns an array of the updated dashboard entry ids
    * @throws Error if batch update failed
    */
   updateBulkApplications(
     applicationData: Array<Partial<ApplicationDashboardDTO>>,
-  ): Promise<Array<number>>
+  ): Promise<Array<number>>;
 }
 
 export default IAppDashboardService;

--- a/backend/typescript/services/interfaces/appDashboardService.ts
+++ b/backend/typescript/services/interfaces/appDashboardService.ts
@@ -1,12 +1,6 @@
 import { ApplicationDashboardDTO, ApplicationDTO } from "../../types";
 
 interface IAppDashboardService {
-  /**
-   * Get user associated with id
-   * @param id user's id
-   * @returns a UserDTO with user's information
-   * @throws Error if user retrieval fails
-   */
   getDashboardById(id: number): Promise<ApplicationDashboardDTO>;
   getApplicationsByRole(role: string): Promise<ApplicationDTO[]>;
   getDashboardsByApplicationId(
@@ -21,6 +15,16 @@ interface IAppDashboardService {
     id: number,
     newValue: string,
   ): Promise<ApplicationDashboardDTO>;
+
+  /**
+   * Bulk updates applications in reviewer dashboard
+   * @param applicationData 
+   * @returns an array of the updated dashboard entry ids
+   * @throws Error if batch update failed
+   */
+  updateBulkApplications(
+    applicationData: Array<Partial<ApplicationDashboardDTO>>,
+  ): Promise<Array<number>>
 }
 
 export default IAppDashboardService;

--- a/backend/typescript/types.ts
+++ b/backend/typescript/types.ts
@@ -25,16 +25,7 @@ export type ApplicationDashboardDTO = {
   applicationId: number;
 };
 
-export type ApplicationDashboardInput = {
-  id: number;
-  reviewerEmail: string;
-  passionFSG: number;
-  teamPlayer: number;
-  desireToLearn: number;
-  skill: number;
-  skillCategory: string;
-  reviewerId: number;
-};
+export type ApplicationDashboardInput = Omit<ApplicationDashboardDTO, "applicationId">;
 
 export type ApplicationDTO = {
   id: number;

--- a/backend/typescript/types.ts
+++ b/backend/typescript/types.ts
@@ -25,6 +25,17 @@ export type ApplicationDashboardDTO = {
   applicationId: number;
 };
 
+export type ApplicationDashboardInput = {
+  id: number;
+  reviewerEmail: string;
+  passionFSG: number;
+  teamPlayer: number;
+  desireToLearn: number;
+  skill: number;
+  skillCategory: string;
+  reviewerId: number;
+};
+
 export type ApplicationDTO = {
   id: number;
   academicYear: string;

--- a/backend/typescript/types.ts
+++ b/backend/typescript/types.ts
@@ -25,7 +25,10 @@ export type ApplicationDashboardDTO = {
   applicationId: number;
 };
 
-export type ApplicationDashboardInput = Omit<ApplicationDashboardDTO, "applicationId">;
+export type ApplicationDashboardInput = Omit<
+  ApplicationDashboardDTO,
+  "applicationId"
+>;
 
 export type ApplicationDTO = {
   id: number;


### PR DESCRIPTION
## Notion ticket link
<!-- Please replace with your ticket's URL -->
[[BE] Applicant Table Editing - Bulk Save Endpoint - Part 1](https://www.notion.so/uwblueprintexecs/BE-Applicant-Table-Editing-Bulk-Save-Endpoint-Part-1-b56c6b5a853c42588657aff6f9ac80ff)


<!-- Give a quick summary of the implementation details, provide design justifications if necessary -->
## Implementation description
Used sequelize update method for each of the dashboard items, instead of bulkCreate, for more readable API call and less required code duplication. Needed to add an ApplicationDashboardInput type for GraphQL, which has pretty much all the same info as ApplicationDashboardDTO (except for applicationId). 



<!-- What should the reviewer do to verify your changes? Describe expected results and include screenshots when appropriate -->
## Steps to test
1. Check the dashboard data in Postman to see what is currently there for application id 1:  
```graphql
query {
    dashboardsByApplicationId(applicationId: 1) {
        id
        reviewerEmail
        passionFSG
        teamPlayer
        desireToLearn
        skill
        skillCategory
        reviewerId
        applicationId
    }
}
```
2. Try the following mutation in Postman: 
```graphql
mutation {
    updateApplications(
        applications: [
            {
                id: 1,
                passionFSG: 2,
                teamPlayer: 2,
                skill: 2
            },
            {
                id: 2,
                passionFSG: 2,
                teamPlayer: 2,
                skillCategory: "junior",
            }
        ]
    )
}
```
3. Try the query from step 1 again to confirm that the fields have been changed. 


<!-- Draw attention to the substantial parts of your PR or anything you'd like a second opinion on -->
## What should reviewers focus on?
I'm unsure about whether we should use sequelize update or bulkCreate (which is sequelize's version of bulkUpdate), as bulkCreate is a little less portable. Also, I'm unsure about what the endpoint should return: I just have it returning a list of the updated dashboard ids, since trying to return the full info results in some issues where the returned array of objects doesn't get populated, as the update.then happens asynchronously. 


## Checklist
- [x] My PR name is descriptive and in imperative tense
- [x] My commit messages are descriptive and in imperative tense. My commits are atomic and trivial commits are squashed or fixup'd into non-trivial commits
- [x] I have run the appropriate linter(s)
- [x] I have requested a review from the PL, as well as other devs who have background knowledge on this PR or who will be building on top of this PR
