### PR TITLE
Token auth setup v2

### DIFF
--- a/backend/typescript/graphql/resolvers/authResolvers.ts
+++ b/backend/typescript/graphql/resolvers/authResolvers.ts
@@ -87,11 +87,9 @@ const authResolvers = {
       _parent: undefined,
       { idToken }: { idToken: string },
     ): // { res }: { res: Response },
-    Promise<Omit<AuthDTO, "refreshToken">> => {
+    Promise<AuthDTO> => {
       const authDTO = await authService.generateTokenOAuth(idToken);
-      const { refreshToken, ...rest } = authDTO;
-      // res.cookie("refreshToken", refreshToken, cookieOptions);
-      return rest;
+      return authDTO;
     },
     register: async (
       _parent: undefined,

--- a/backend/typescript/graphql/resolvers/authResolvers.ts
+++ b/backend/typescript/graphql/resolvers/authResolvers.ts
@@ -10,7 +10,7 @@ import IEmailService from "../../services/interfaces/emailService";
 import FirebaseRestClient from "../../utilities/firebaseRestClient";
 import IUserService from "../../services/interfaces/userService";
 import User from "../../models/user.model";
-import { AuthDTO, RegisterUserDTO } from "../../types";
+import { AuthDTO, RegisterUserDTO, Role } from "../../types";
 
 const userService: IUserService = new UserService();
 const emailService: IEmailService = new EmailService(nodemailerConfig);
@@ -40,6 +40,18 @@ const splitName = (
 };
 
 const authResolvers = {
+  Query: {
+    isAuthorizedByRole: async (
+      _parent: undefined,
+      { accessToken, roles }: { accessToken: string; roles: Role[] },
+    ): Promise<boolean> => {
+      const isAuthorized = await authService.isAuthorizedByRole(
+        accessToken,
+        new Set(roles),
+      );
+      return isAuthorized;
+    },
+  },
   Mutation: {
     login: async (
       _parent: undefined,
@@ -95,6 +107,25 @@ const authResolvers = {
       await authService.sendEmailVerificationLink(user.email);
       res.cookie("refreshToken", refreshToken, cookieOptions);
       return rest;
+    },
+    registerFirebaseUser: async (
+      _parent: undefined,
+      {
+        user,
+        authId,
+        role,
+      }: { user: RegisterUserDTO; authId: string; role: Role },
+    ): Promise<boolean> => {
+      // If User is already in postgres, don't create a new entry
+      User.findOne({ where: { auth_id: authId } }).then(async (found) => {
+        if (found) {
+          User.update({ ...user, role }, { where: { auth_id: authId } });
+        } else {
+          await userService.createUser({ ...user, role }, authId, "GOOGLE");
+        }
+        await authService.sendEmailVerificationLink(user.email);
+      });
+      return true;
     },
     refresh: async (
       _parent: undefined,

--- a/backend/typescript/graphql/resolvers/authResolvers.ts
+++ b/backend/typescript/graphql/resolvers/authResolvers.ts
@@ -91,21 +91,6 @@ const authResolvers = {
       const authDTO = await authService.generateTokenOAuth(idToken);
       return authDTO;
     },
-    register: async (
-      _parent: undefined,
-      { user }: { user: RegisterUserDTO },
-      { res }: { res: Response },
-    ): Promise<Omit<AuthDTO, "refreshToken">> => {
-      await userService.createUser({ ...user, role: "User" });
-      const authDTO = await authService.generateToken(
-        user.email,
-        user.password,
-      );
-      const { refreshToken, ...rest } = authDTO;
-      await authService.sendEmailVerificationLink(user.email);
-      res.cookie("refreshToken", refreshToken, cookieOptions);
-      return rest;
-    },
     registerFirebaseUser: async (
       _parent: undefined,
       {

--- a/backend/typescript/graphql/types/authType.ts
+++ b/backend/typescript/graphql/types/authType.ts
@@ -23,12 +23,18 @@ const authType = gql`
 
   extend type Query {
     login(email: String!, password: String!): loginOK!
+    isAuthorizedByRole(accessToken: String!, roles: [Role!]!): Boolean!
   }
 
   extend type Mutation {
     login(email: String!, password: String!): AuthDTO!
     loginWithGoogle(idToken: String!): AuthDTO!
     register(user: RegisterUserDTO!): AuthDTO!
+    registerFirebaseUser(
+      user: RegisterUserDTO!
+      authId: String!
+      role: Role!
+    ): Boolean!
     refresh: String!
     logout(userId: ID!): ID
     resetPassword(email: String!): Boolean!

--- a/backend/typescript/graphql/types/authType.ts
+++ b/backend/typescript/graphql/types/authType.ts
@@ -8,6 +8,7 @@ const authType = gql`
     email: String!
     role: Role!
     accessToken: String!
+    refreshToken: String!
   }
 
   type loginOK {

--- a/backend/typescript/graphql/types/authType.ts
+++ b/backend/typescript/graphql/types/authType.ts
@@ -30,7 +30,6 @@ const authType = gql`
   extend type Mutation {
     login(email: String!, password: String!): AuthDTO!
     loginWithGoogle(idToken: String!): AuthDTO!
-    register(user: RegisterUserDTO!): AuthDTO!
     registerFirebaseUser(
       user: RegisterUserDTO!
       authId: String!

--- a/backend/typescript/services/implementations/authService.ts
+++ b/backend/typescript/services/implementations/authService.ts
@@ -157,7 +157,7 @@ class AuthService implements IAuthService {
       this.emailService.sendEmail(email, "Verify your email", emailBody);
     } catch (error) {
       Logger.error(
-        `Failed to generate email verification link for user with email ${email}`,
+        `Failed to generate email verification link for user with email ${email} ${error}`,
       );
       throw error;
     }

--- a/backend/typescript/services/implementations/authService.ts
+++ b/backend/typescript/services/implementations/authService.ts
@@ -60,11 +60,8 @@ class AuthService implements IAuthService {
 
       const user = await this.userService.createUser(
         {
-          firstName: googleUser.firstName,
-          lastName: googleUser.lastName,
           email: googleUser.email,
           role: "User",
-          password: "",
         },
         googleUser.localId,
         "GOOGLE",

--- a/backend/typescript/services/implementations/userService.ts
+++ b/backend/typescript/services/implementations/userService.ts
@@ -145,27 +145,20 @@ class UserService implements IUserService {
   async createUser(
     user: CreateUserDTO,
     authId?: string,
-    signUpMethod = "PASSWORD",
   ): Promise<UserDTO> {
     let newUser: User;
     let firebaseUser: firebaseAdmin.auth.UserRecord;
 
     try {
-      if (signUpMethod === "GOOGLE") {
-        /* eslint-disable-next-line @typescript-eslint/no-non-null-assertion */
-        firebaseUser = await firebaseAdmin.auth().getUser(authId!);
-      } else {
-        // signUpMethod === PASSWORD
-        firebaseUser = await firebaseAdmin.auth().createUser({
-          email: user.email,
-          password: user.password,
-        });
-      }
-
+      /* eslint-disable-next-line @typescript-eslint/no-non-null-assertion */
+      firebaseUser = await firebaseAdmin.auth().getUser(authId!);
+      if (!firebaseUser.displayName) throw Error("Firebase username and password not available")
+      const [firstName, lastName] = firebaseUser.displayName?.split(" ");
+      
       try {
         newUser = await User.create({
-          first_name: user.firstName,
-          last_name: user.lastName,
+          first_name: firstName,
+          last_name: lastName,
           auth_id: firebaseUser.uid,
           email: firebaseUser.email,
           role: user.role,

--- a/backend/typescript/services/implementations/userService.ts
+++ b/backend/typescript/services/implementations/userService.ts
@@ -167,6 +167,7 @@ class UserService implements IUserService {
           first_name: user.firstName,
           last_name: user.lastName,
           auth_id: firebaseUser.uid,
+          email: firebaseUser.email,
           role: user.role,
         });
       } catch (postgresError) {

--- a/backend/typescript/services/implementations/userService.ts
+++ b/backend/typescript/services/implementations/userService.ts
@@ -142,19 +142,17 @@ class UserService implements IUserService {
     return userDtos;
   }
 
-  async createUser(
-    user: CreateUserDTO,
-    authId?: string,
-  ): Promise<UserDTO> {
+  async createUser(user: CreateUserDTO, authId?: string): Promise<UserDTO> {
     let newUser: User;
     let firebaseUser: firebaseAdmin.auth.UserRecord;
 
     try {
       /* eslint-disable-next-line @typescript-eslint/no-non-null-assertion */
       firebaseUser = await firebaseAdmin.auth().getUser(authId!);
-      if (!firebaseUser.displayName) throw Error("Firebase username and password not available")
+      if (!firebaseUser.displayName)
+        throw Error("Firebase username and password not available");
       const [firstName, lastName] = firebaseUser.displayName?.split(" ");
-      
+
       try {
         newUser = await User.create({
           first_name: firstName,

--- a/backend/typescript/types.ts
+++ b/backend/typescript/types.ts
@@ -61,7 +61,7 @@ export type ApplicationDTO = {
   timestamp: bigint;
 };
 
-export type CreateUserDTO = Omit<UserDTO, "id"> & { password: string };
+export type CreateUserDTO = Omit<UserDTO, "id" | "firstName" | "lastName">;
 
 export type UpdateUserDTO = Omit<UserDTO, "id">;
 


### PR DESCRIPTION
## Notion ticket link
<!-- Please replace with your ticket's URL -->
[[FE] Dashboard - Authentication & Saving Token](https://www.notion.so/uwblueprintexecs/FE-Dashboard-Authentication-Saving-Token-f537cc9fb44c4c0e92df387635475317)


<!-- Give a quick summary of the implementation details, provide design justifications if necessary -->
## Implementation description
* Added backend IsAuthorizedByRole route for verifying a user role using their refresh token.


<!-- What should the reviewer do to verify your changes? Describe expected results and include screenshots when appropriate -->
## Steps to test
1. Test isAuthorizedByRole with the following body on endpoint `http://localhost:5000/graphql`
```
query isAuthorizedByRole{
    isAuthorizedByRole(accessToken: <YOUR_ACCESS_TOKEN>, roles: <ROLES>)
}
```
For example:

```
query isAuthorizedByRole{
    isAuthorizedByRole(accessToken: "eyJhbGciOiJSUzI1NiIsImtpZCI6IjU0NWUyNDZjNTEwNmExMGQ2MzFiMTA0M2E3MWJiNTllNWJhMGM5NGQiLCJ0eXAiOiJKV1QifQ.eyJpc3MiOiJodHRwczovL3NlY3VyZXRva2VuLmdvb2dsZS5jb20vdXctYmx1ZXByaW50IiwiYXVkIjoidXctYmx1ZXByaW50IiwiYXV0aF90aW1lIjoxNjg1NjY3MDY5LCJ1c2VyX2lkIjoiOG5MZDgwellhT1hHSXlMQUY2OU1TSmdqZGIyMiIsInN1YiI6IjhuTGQ4MHpZYU9YR0l5TEFGNjlNU0pnamRiMjIiLCJpYXQiOjE2ODU2NjcwNjksImV4cCI6MTY4NTY3MDY2OSwiZW1haWwiOiJ0aG9tYXMud3U5MzFAZ21haWwuY29tIiwiZW1haWxfdmVyaWZpZWQiOnRydWUsImZpcmViYXNlIjp7ImlkZW50aXRpZXMiOnsiZW1haWwiOlsidGhvbWFzLnd1OTMxQGdtYWlsLmNvbSJdfSwic2lnbl9pbl9wcm92aWRlciI6InBhc3N3b3JkIn19.vU5IY8LtVxxOUB-7a8_VwxigLoX-Feq1JoW6CSqCbA-f3odg9kPySl2RHTl6uobsUDhXzE-tSRWhtvpeAnWwOm1p_h3P6DQnAs6o9LlFJZAJjq9f9k0zJgPUBBa56ber72L7viA3lMGsCc3nagL08VXwD0gyfssy4P4wLYODP6uubOL8WyIcLWrWa4l3d9Fdcdejcft4uDYpbvcqnpGnhObMizlNYxjfYkcpjJLm4z4b-hns6UIJkXaHxxLZpaWdIiUpn_EPJS2PnsKJSyiCFPFwMwpNCpdjIW873c7vw9b_g9-XWFxlSBTVXsRy3mZrc3ycYPEXrxXaf6ekjJCwIg", roles: [Admin])
}
```


<!-- Draw attention to the substantial parts of your PR or anything you'd like a second opinion on -->
## What should reviewers focus on?
* Unsure of how I'm handling the transfer of data from frontend to GraphQl to typescript. Both the frontend, backend, and GraphQl have their own unique definitions of the Roles object (Which is either "Admin" or "User"). Maybe we can unify the definitions to come from one, singular source.
* All of the existing implementation features aren't "complete". We still need to create middleware which automatically refreshes the access token if it is expired and update isAuthorizedByRole to try. We also need to edit all endpoints which accept an accessToken to also accept a refreshToken because of the previous sentence. 


## Checklist
- [x] My PR name is descriptive and in imperative tense
- [x] My commit messages are descriptive and in imperative tense. My commits are atomic and trivial commits are squashed or fixup'd into non-trivial commits
- [x] I have run the appropriate linter(s)
- [x] I have requested a review from the PL, as well as other devs who have background knowledge on this PR or who will be building on top of this PR
