### PR TITLE
fix refresh endpoint

### DIFF
--- a/backend/typescript/graphql/resolvers/authResolvers.ts
+++ b/backend/typescript/graphql/resolvers/authResolvers.ts
@@ -112,11 +112,9 @@ const authResolvers = {
     },
     refresh: async (
       _parent: undefined,
-      _args: Record<string, undefined>,
-      { req, res }: { req: Request; res: Response },
+      { refreshToken }: { refreshToken: string },
     ): Promise<string> => {
-      const token = await authService.renewToken(req.cookies.refreshToken);
-      res.cookie("refreshToken", token.refreshToken, cookieOptions);
+      const token = await authService.renewToken(refreshToken);
       return token.accessToken;
     },
     logout: async (

--- a/backend/typescript/graphql/types/authType.ts
+++ b/backend/typescript/graphql/types/authType.ts
@@ -35,7 +35,7 @@ const authType = gql`
       authId: String!
       role: Role!
     ): Boolean!
-    refresh: String!
+    refresh(refreshToken: String!): String!
     logout(userId: ID!): ID
     resetPassword(email: String!): Boolean!
   }


### PR DESCRIPTION
## Notion ticket link
<!-- Please replace with your ticket's URL -->
[Handle Automatic Token Refreshing](https://www.notion.so/uwblueprintexecs/58fdb7043f98414aa6f88c7ec827d5ca?v=9df8cc8e794b4d9ea4152c1253b876d6&p=343f22774e044c669148424cac12b228&pm=s)


<!-- Give a quick summary of the implementation details, provide design justifications if necessary -->
## Implementation description
* Change the refresh endpoint by removing unused _args parameter


<!-- What should the reviewer do to verify your changes? Describe expected results and include screenshots when appropriate -->
## Steps to test
1. Use the follow refresh request as an example on graphql playground. The output should give an access token like the screen shot.
```
          mutation refreshUser {
            refresh(refreshToken: "APZUo0TXb_woennwlz7dQVp28L2zt22qPoLautPDDRN7tRmOqThVa1QyIJ7ZXo5NRfNMKBS-7pEfIGXsR8ORmRE7IFVPIBce5Uw3CgpwgqVSFRwA10DnDSowyerkw2o0JPJAetBrH-fhHi5yf1ovP-rCO2oz0b8oSurbtGhssZZF980Q271UVOwyfXYHGMCS-74q0MwOFlp4In6AqigBJbXwJYTR60lL_i23BIZqeqadQ4ZaFf4hVDJ8cWi0HAQcRfvP6LH2yqjCkhe9CuiCRsoO_ufBgOEZKQ")
          }
```
<img width="1440" alt="Screen Shot 2023-06-15 at 2 26 55 PM" src="https://github.com/uwblueprint/website-bp-be/assets/117593511/b6043ca6-63b0-4dfa-af95-f5c390a6cd4d">```



<!-- Draw attention to the substantial parts of your PR or anything you'd like a second opinion on -->
## What should reviewers focus on?
* NA


## Checklist
- [x] My PR name is descriptive and in imperative tense
- [x] My commit messages are descriptive and in imperative tense. My commits are atomic and trivial commits are squashed or fixup'd into non-trivial commits
- [x] I have run the appropriate linter(s)
- [x] I have requested a review from the PL, as well as other devs who have background knowledge on this PR or who will be building on top of this PR
