### PR TITLE
INTS25 Create Reviewed Application Service Mutators

### DIFF
--- a/backend/typescript/graphql/index.ts
+++ b/backend/typescript/graphql/index.ts
@@ -1,6 +1,6 @@
 import { makeExecutableSchema, gql } from "apollo-server-express";
 import { applyMiddleware } from "graphql-middleware";
-import { merge } from "lodash";
+import { create, merge } from "lodash";
 
 import {
   isAuthorizedByEmail,
@@ -18,6 +18,8 @@ import userType from "./types/userType";
 import dashboardType from "./types/dashboardType";
 import dashboardResolvers from "./resolvers/dashboardResolvers";
 import reviewType from "./types/reviewType";
+import reviewedApplicantRecordType from "./types/reviewedApplicantRecordType";
+import reviewedApplicantRecordResolvers from "./resolvers/reviewedApplicantRecordResolver";
 
 const query = gql`
   type Query {
@@ -41,6 +43,7 @@ const executableSchema = makeExecutableSchema({
     simpleEntityType,
     userType,
     dashboardType,
+    reviewedApplicantRecordType,
   ],
   resolvers: merge(
     authResolvers,
@@ -48,6 +51,7 @@ const executableSchema = makeExecutableSchema({
     simpleEntityResolvers,
     userResolvers,
     dashboardResolvers,
+    reviewedApplicantRecordResolvers,
   ),
 });
 
@@ -90,6 +94,12 @@ const graphQLMiddlewares = {
     logout: isAuthorizedByUserId("userId"),
     resetPassword: isAuthorizedByEmail("email"),
     sendSignInLink: authorizedByAllRoles(),
+
+    // this should be guarded by isAuthorizedReviewerForApplication once it is implemented
+    createReviewedApplicantRecord: authorizedByAllRoles(),
+    bulkCreateReviewedApplicantRecords: authorizedByAllRoles(),
+    updateReviewedApplicantRecordReview: authorizedByAllRoles(),
+    updateReviewedApplicantRecordStatus: authorizedByAllRoles(),
   },
 };
 

--- a/backend/typescript/graphql/resolvers/reviewedApplicantRecordResolver.ts
+++ b/backend/typescript/graphql/resolvers/reviewedApplicantRecordResolver.ts
@@ -1,0 +1,71 @@
+import ReviewedApplicantRecordService from "../../services/implementations/reviewedApplicantRecordService";
+import { IReviewedApplicantRecordService } from "../../services/interfaces/reviewedApplicantRecordService";
+import {
+  Review,
+  ReviewedApplicantRecordDTO,
+  ReviewedApplicantRecordPK,
+  ReviewStatus,
+} from "../../types";
+
+const reviewedApplicantRecordService: IReviewedApplicantRecordService =
+  new ReviewedApplicantRecordService();
+
+const reviewedApplicantRecordResolvers = {
+  Mutation: {
+    createReviewedApplicantRecord: async (
+      _parent: undefined,
+      {
+        reviewedApplicantRecordPK,
+      }: { reviewedApplicantRecordPK: ReviewedApplicantRecordPK },
+    ): Promise<ReviewedApplicantRecordDTO> => {
+      return reviewedApplicantRecordService.createReviewedApplicantRecord(
+        reviewedApplicantRecordPK,
+      );
+    },
+
+    bulkCreateReviewedApplicantRecords: async (
+      _parent: undefined,
+      {
+        reviewedApplicantRecordPKs,
+      }: { reviewedApplicantRecordPKs: ReviewedApplicantRecordPK[] },
+    ): Promise<ReviewedApplicantRecordDTO[]> => {
+      return reviewedApplicantRecordService.bulkCreateReviewedApplicantRecords(
+        reviewedApplicantRecordPKs,
+      );
+    },
+
+    updateReviewedApplicantRecordReview: async (
+      _parent: undefined,
+      {
+        reviewedApplicantRecordPK,
+        review,
+      }: {
+        reviewedApplicantRecordPK: ReviewedApplicantRecordPK;
+        review: Review;
+      },
+    ): Promise<ReviewedApplicantRecordDTO> => {
+      return reviewedApplicantRecordService.updateReviewedApplicantRecordReview(
+        reviewedApplicantRecordPK,
+        review,
+      );
+    },
+
+    updateReviewedApplicantRecordStatus: async (
+      _parent: undefined,
+      {
+        reviewedApplicantRecordPK,
+        status,
+      }: {
+        reviewedApplicantRecordPK: ReviewedApplicantRecordPK;
+        status: ReviewStatus;
+      },
+    ): Promise<ReviewedApplicantRecordDTO> => {
+      return reviewedApplicantRecordService.updateReviewedApplicantRecordStatus(
+        reviewedApplicantRecordPK,
+        status,
+      );
+    },
+  },
+};
+
+export default reviewedApplicantRecordResolvers;

--- a/backend/typescript/graphql/types/reviewedApplicantRecordType.ts
+++ b/backend/typescript/graphql/types/reviewedApplicantRecordType.ts
@@ -1,0 +1,59 @@
+import { gql } from "apollo-server-express";
+
+const reviewedApplicantRecordType = gql`
+  type Review {
+    passionFSG: Int
+    teamPlayer: Int
+    desireToLearn: Int
+    skill: Int
+    skillCategory: SkillCategory
+  }
+
+  enum SkillCategory {
+    Junior
+    Intermediate
+    Senior
+  }
+
+  input ReviewInput {
+    passionFSG: Int
+    teamPlayer: Int
+    desireToLearn: Int
+    skill: Int
+    skillCategory: SkillCategory
+  }
+
+  type ReviewedApplicantRecordDTO {
+    applicantRecordId: ID!
+    reviewerId: ID!
+    review: Review
+    status: String!
+  }
+
+  input ReviewedApplicantRecordPK {
+    reviewerId: ID!
+    applicantRecordId: ID!
+  }
+
+  extend type Mutation {
+    createReviewedApplicantRecord(
+      reviewedApplicantRecordPK: ReviewedApplicantRecordPK!
+    ): ReviewedApplicantRecordDTO!
+
+    bulkCreateReviewedApplicantRecords(
+      reviewedApplicantRecordPKs: [ReviewedApplicantRecordPK!]!
+    ): [ReviewedApplicantRecordDTO!]!
+
+    updateReviewedApplicantRecordReview(
+      reviewedApplicantRecordPK: ReviewedApplicantRecordPK!
+      review: ReviewInput!
+    ): ReviewedApplicantRecordDTO!
+
+    updateReviewedApplicantRecordStatus(
+      reviewedApplicantRecordPK: ReviewedApplicantRecordPK!
+      status: String!
+    ): ReviewedApplicantRecordDTO!
+  }
+`;
+
+export default reviewedApplicantRecordType;

--- a/backend/typescript/migrations/20250806003006-add-created-at-and-updated-at.ts
+++ b/backend/typescript/migrations/20250806003006-add-created-at-and-updated-at.ts
@@ -1,0 +1,78 @@
+import { DataType } from "sequelize-typescript";
+import { Migration } from "../umzug";
+
+const REVIEWED_APPLICANT_RECORDS_TABLE = "reviewed_applicant_records";
+const APPLICANT_RECORD_TABLE = "applicant_records";
+const POSITIONS_TABLE = "positions";
+
+export const up: Migration = async ({ context: sequelize }) => {
+  await sequelize
+    .getQueryInterface()
+    .addColumn(REVIEWED_APPLICANT_RECORDS_TABLE, "createdAt", {
+      type: DataType.DATE,
+      allowNull: true,
+      defaultValue: DataType.NOW,
+    });
+
+  await sequelize
+    .getQueryInterface()
+    .addColumn(REVIEWED_APPLICANT_RECORDS_TABLE, "updatedAt", {
+      type: DataType.DATE,
+      allowNull: true,
+      defaultValue: DataType.NOW,
+    });
+
+  await sequelize
+    .getQueryInterface()
+    .addColumn(APPLICANT_RECORD_TABLE, "createdAt", {
+      type: DataType.DATE,
+      allowNull: true,
+      defaultValue: DataType.NOW,
+    });
+
+  await sequelize
+    .getQueryInterface()
+    .addColumn(APPLICANT_RECORD_TABLE, "updatedAt", {
+      type: DataType.DATE,
+      allowNull: true,
+      defaultValue: DataType.NOW,
+    });
+
+  await sequelize.getQueryInterface().addColumn(POSITIONS_TABLE, "createdAt", {
+    type: DataType.DATE,
+    allowNull: true,
+    defaultValue: DataType.NOW,
+  });
+
+  await sequelize.getQueryInterface().addColumn(POSITIONS_TABLE, "updatedAt", {
+    type: DataType.DATE,
+    allowNull: true,
+    defaultValue: DataType.NOW,
+  });
+};
+
+export const down: Migration = async ({ context: sequelize }) => {
+  await sequelize
+    .getQueryInterface()
+    .removeColumn(REVIEWED_APPLICANT_RECORDS_TABLE, "createdAt");
+
+  await sequelize
+    .getQueryInterface()
+    .removeColumn(REVIEWED_APPLICANT_RECORDS_TABLE, "updatedAt");
+
+  await sequelize
+    .getQueryInterface()
+    .removeColumn(APPLICANT_RECORD_TABLE, "createdAt");
+
+  await sequelize
+    .getQueryInterface()
+    .removeColumn(APPLICANT_RECORD_TABLE, "updatedAt");
+
+  await sequelize
+    .getQueryInterface()
+    .removeColumn(POSITIONS_TABLE, "createdAt");
+
+  await sequelize
+    .getQueryInterface()
+    .removeColumn(POSITIONS_TABLE, "updatedAt");
+};

--- a/backend/typescript/models/applicant.model.ts
+++ b/backend/typescript/models/applicant.model.ts
@@ -5,10 +5,9 @@ import { Column, DataType, Model, Table } from "sequelize-typescript";
 @Table({ tableName: "applicants" })
 export default class Applicant extends Model {
   @Column({
-    type: DataType.INTEGER,
+    type: DataType.STRING,
     primaryKey: true,
     unique: true,
-    autoIncrement: true,
   })
   id!: string;
 

--- a/backend/typescript/models/applicantRecord.model.ts
+++ b/backend/typescript/models/applicantRecord.model.ts
@@ -18,12 +18,11 @@ import Position from "./position.model";
 @Table({ tableName: "applicant_records" })
 export default class ApplicantRecord extends Model {
   @Column({
-    type: DataType.INTEGER,
+    type: DataType.STRING,
     primaryKey: true,
     unique: true,
-    autoIncrement: true,
   })
-  id!: string;
+  id!: number;
 
   @ForeignKey(() => Applicant)
   @Column({ type: DataType.STRING })
@@ -47,4 +46,18 @@ export default class ApplicantRecord extends Model {
 
   @Column({ type: DataType.JSONB, allowNull: true })
   extraInfo!: ApplicantRecordExtraInfo;
+
+  @Column({
+    type: DataType.DATE,
+    allowNull: true,
+    defaultValue: DataType.NOW,
+  })
+  createdAt!: Date;
+
+  @Column({
+    type: DataType.DATE,
+    allowNull: true,
+    defaultValue: DataType.NOW,
+  })
+  updatedAt!: Date;
 }

--- a/backend/typescript/models/position.model.ts
+++ b/backend/typescript/models/position.model.ts
@@ -8,4 +8,18 @@ export default class Position extends Model {
 
   @Column({ type: DataType.ENUM(...Object.values(Department)) })
   department!: Department;
+
+  @Column({
+    type: DataType.DATE,
+    allowNull: true,
+    defaultValue: DataType.NOW,
+  })
+  createdAt!: Date;
+
+  @Column({
+    type: DataType.DATE,
+    allowNull: true,
+    defaultValue: DataType.NOW,
+  })
+  updatedAt!: Date;
 }

--- a/backend/typescript/models/reviewedApplicantRecord.model.ts
+++ b/backend/typescript/models/reviewedApplicantRecord.model.ts
@@ -29,4 +29,18 @@ export default class ReviewedApplicantRecord extends Model {
     defaultValue: ReviewStatusEnum.TODO,
   })
   status!: ReviewStatus;
+
+  @Column({
+    type: DataType.DATE,
+    allowNull: true,
+    defaultValue: DataType.NOW,
+  })
+  createdAt!: Date;
+
+  @Column({
+    type: DataType.DATE,
+    allowNull: true,
+    defaultValue: DataType.NOW,
+  })
+  updatedAt!: Date;
 }

--- a/backend/typescript/services/implementations/reviewedApplicantRecordService.ts
+++ b/backend/typescript/services/implementations/reviewedApplicantRecordService.ts
@@ -1,0 +1,191 @@
+import ReviewedApplicantRecord from "../../models/reviewedApplicantRecord.model";
+import {
+  Review,
+  ReviewedApplicantRecordDTO,
+  ReviewedApplicantRecordPK,
+  ReviewStatus,
+  ReviewStatusEnum,
+  SkillCategoryEnum,
+} from "../../types";
+import { IReviewedApplicantRecordService } from "../interfaces/reviewedApplicantRecordService";
+import { sequelize } from "../../models";
+import logger from "../../utilities/logger";
+import { getErrorMessage } from "../../utilities/errorUtils";
+
+const Logger = logger(__filename);
+
+class ReviewedApplicantRecordService
+  implements IReviewedApplicantRecordService
+{
+  createReviewedApplicantRecord = async (
+    reviewedApplicantRecordPK: ReviewedApplicantRecordPK,
+  ): Promise<ReviewedApplicantRecordDTO> => {
+    const { reviewerId, applicantRecordId } = reviewedApplicantRecordPK;
+    try {
+      const createdRecord = await sequelize.transaction(async (transaction) =>
+        ReviewedApplicantRecord.create(
+          {
+            reviewerId,
+            applicantRecordId,
+            status: ReviewStatusEnum.TODO,
+          },
+          { transaction },
+        ),
+      );
+
+      return {
+        applicantRecordId: createdRecord.applicantRecordId,
+        reviewerId: createdRecord.reviewerId,
+        review: createdRecord.review,
+        status: createdRecord.status,
+      } as ReviewedApplicantRecordDTO;
+    } catch (error) {
+      Logger.error(
+        `Error in createReviewedApplicantRecord: ${getErrorMessage(error)}`,
+      );
+      throw error;
+    }
+  };
+
+  bulkCreateReviewedApplicantRecords = async (
+    reviewedApplicantRecordPKs: ReviewedApplicantRecordPK[],
+  ): Promise<ReviewedApplicantRecordDTO[]> => {
+    try {
+      const recordsToCreate = reviewedApplicantRecordPKs.map(
+        ({ reviewerId, applicantRecordId }) => ({
+          reviewerId,
+          applicantRecordId,
+          status: ReviewStatusEnum.TODO,
+        }),
+      );
+
+      const createdRecords = await sequelize.transaction(async (transaction) =>
+        ReviewedApplicantRecord.bulkCreate(recordsToCreate, {
+          transaction,
+          returning: true,
+        }),
+      );
+
+      return createdRecords.map(
+        (record) =>
+          ({
+            applicantRecordId: record.applicantRecordId,
+            reviewerId: record.reviewerId,
+            review: record.review,
+            status: record.status,
+          } as ReviewedApplicantRecordDTO),
+      );
+    } catch (error) {
+      Logger.error(
+        `Error in bulkCreateReviewedApplicantRecords: ${getErrorMessage(
+          error,
+        )}`,
+      );
+      throw error;
+    }
+  };
+
+  updateReviewedApplicantRecordReview = async (
+    reviewedApplicantRecordPK: ReviewedApplicantRecordPK,
+    review: Review,
+  ): Promise<ReviewedApplicantRecordDTO> => {
+    const { reviewerId, applicantRecordId } = reviewedApplicantRecordPK;
+    try {
+      if (
+        review.skillCategory &&
+        !Object.values(SkillCategoryEnum).includes(
+          review.skillCategory as SkillCategoryEnum,
+        )
+      ) {
+        throw new Error("Review has invalid skill category");
+      }
+
+      const updatedReviewedApplicantRecord = await sequelize.transaction(
+        async (transaction) => {
+          const reviewedApplicantRecord = await ReviewedApplicantRecord.findOne(
+            {
+              where: { reviewerId, applicantRecordId },
+              transaction,
+            },
+          );
+
+          if (!reviewedApplicantRecord) {
+            throw new Error(
+              `Reviewed applicant record with reviewerId ${reviewerId} and applicantRecordId ${applicantRecordId} not found`,
+            );
+          }
+
+          reviewedApplicantRecord.review = review;
+          await reviewedApplicantRecord.save({ transaction });
+
+          return {
+            applicantRecordId: reviewedApplicantRecord.applicantRecordId,
+            reviewerId: reviewedApplicantRecord.reviewerId,
+            review: reviewedApplicantRecord.review,
+            status: reviewedApplicantRecord.status,
+          } as ReviewedApplicantRecordDTO;
+        },
+      );
+
+      return updatedReviewedApplicantRecord;
+    } catch (error) {
+      Logger.error(
+        `Unable to update the status of reviewed applicant record (reviewerId=${reviewerId}, applicantRecordId=${applicantRecordId}). Reason: ${getErrorMessage(
+          error,
+        )}`,
+      );
+      throw error;
+    }
+  };
+
+  updateReviewedApplicantRecordStatus = async (
+    reviewedApplicantRecordPK: ReviewedApplicantRecordPK,
+    status: ReviewStatus,
+  ): Promise<ReviewedApplicantRecordDTO> => {
+    const { reviewerId, applicantRecordId } = reviewedApplicantRecordPK;
+
+    try {
+      if (
+        !Object.values(ReviewStatusEnum).includes(status as ReviewStatusEnum)
+      ) {
+        throw new Error("Invalid review status");
+      }
+      const updatedReviewedApplicantRecord = await sequelize.transaction(
+        async (transaction) => {
+          const reviewedApplicantRecord = await ReviewedApplicantRecord.findOne(
+            {
+              where: { reviewerId, applicantRecordId },
+              transaction,
+            },
+          );
+
+          if (!reviewedApplicantRecord) {
+            throw new Error(
+              `Reviewed applicant record with reviewerId ${reviewerId} and applicantRecordId ${applicantRecordId} not found`,
+            );
+          }
+
+          reviewedApplicantRecord.status = status;
+          await reviewedApplicantRecord.save({ transaction });
+
+          return {
+            applicantRecordId: reviewedApplicantRecord.applicantRecordId,
+            reviewerId: reviewedApplicantRecord.reviewerId,
+            review: reviewedApplicantRecord.review,
+            status: reviewedApplicantRecord.status,
+          } as ReviewedApplicantRecordDTO;
+        },
+      );
+
+      return updatedReviewedApplicantRecord;
+    } catch (error) {
+      Logger.error(
+        `Unable to update the status of reviewed applicant record (reviewerId=${reviewerId}, applicantRecordId=${applicantRecordId}). Reason: ${getErrorMessage(
+          error,
+        )}`,
+      );
+      throw error;
+    }
+  };
+}
+export default ReviewedApplicantRecordService;

--- a/backend/typescript/services/interfaces/reviewedApplicantRecordService.ts
+++ b/backend/typescript/services/interfaces/reviewedApplicantRecordService.ts
@@ -1,0 +1,52 @@
+import {
+  Review,
+  ReviewedApplicantRecordDTO,
+  ReviewedApplicantRecordPK,
+  ReviewStatus,
+} from "../../types";
+
+export interface IReviewedApplicantRecordService {
+  /**
+   * Create a reviewed applicant record
+   * @param reviewedApplicantRecordPK the primary key of the reviewed applicant record to create
+   * @returns a ReviewedApplicantRecordDTO with the created reviewed applicant record's information
+   * @throws Error if creation fails
+   */
+  createReviewedApplicantRecord(
+    reviewedApplicantRecordPK: ReviewedApplicantRecordPK,
+  ): Promise<ReviewedApplicantRecordDTO>;
+
+  /**
+   * Bulk create reviewed applicant records
+   * @param reviewedApplicantRecordPKs An array of primary keys identifying the reviewed applicant records to create.
+   * For each primary key, a new reviewed applicant record will be created using data associated with that key.
+   * @returns a ReviewedApplicantRecordDTO array with the created reviewed applicant records' information
+   * @throws Error if creation fails
+   */
+  bulkCreateReviewedApplicantRecords(
+    reviewedApplicantRecordPKs: ReviewedApplicantRecordPK[],
+  ): Promise<ReviewedApplicantRecordDTO[]>;
+
+  /**
+   * Get a reviewed applicant record by its primary key
+   * @param reviewedApplicantRecordPK the primary key of the reviewed applicant record
+   * @returns a ReviewedApplicantRecordDTO with the reviewed applicant record's information
+   * @throws Error if retrieval fails
+   */
+  updateReviewedApplicantRecordReview(
+    reviewedApplicantRecordPK: ReviewedApplicantRecordPK,
+    review: Review,
+  ): Promise<ReviewedApplicantRecordDTO>;
+
+  /**
+   * Update the status of a reviewed applicant record
+   * @param reviewedApplicantRecordPK the primary key of the reviewed applicant record
+   * @param status the new status to set
+   * @returns a ReviewedApplicantRecordDTO with the updated status
+   * @throws Error if update fails
+   */
+  updateReviewedApplicantRecordStatus(
+    reviewedApplicantRecordPK: ReviewedApplicantRecordPK,
+    status: ReviewStatus,
+  ): Promise<ReviewedApplicantRecordDTO>;
+}

--- a/backend/typescript/types.ts
+++ b/backend/typescript/types.ts
@@ -115,7 +115,12 @@ export type ApplicationStatus =
   | "Offer"
   | "Not Considered";
 
-export type SkillCategory = "Junior" | "Intermediate" | "Senior";
+export enum SkillCategoryEnum {
+  Junior = "Junior",
+  Intermediate = "Intermediate",
+  Senior = "Senior",
+}
+export type SkillCategory = `${SkillCategoryEnum}`;
 
 export type ApplicantRecordExtraInfo = {
   adminReview?: string;
@@ -231,8 +236,13 @@ export type Review = {
 };
 
 export type ReviewedApplicantRecordDTO = {
-  applicantRecordId: string;
+  applicantRecordId: number;
   reviewerId: number;
   review: Review;
   status: ReviewStatus;
+};
+
+export type ReviewedApplicantRecordPK = {
+  reviewerId: number;
+  applicantRecordId: number;
 };


### PR DESCRIPTION
## Notion ticket link
<!-- Please replace with your ticket's URL -->
[Create Reviewed Application Services + Mutators](https://www.notion.so/uwblueprintexecs/Create-Reviewed-Application-Services-Mutators-21510f3fb1dc80c68265e3a4e1473aa4?v=20410f3fb1dc80c38480000c1ecb6682&source=copy_link)


<!-- Give a quick summary of the implementation details, provide design justifications if necessary -->
## Implementation description
- Added reviewed application mutators: 
  - `CreateReviewedApplicantRecord`: creates one reviewed application entry
  - `BulkCreateReviewedApplicantRecords`: creates multiple empty reviewed application entries, entire application fails if one creation fails
  - `UpdateApplicantRecordReview`:  Saves review scores and comments to the appropriate applicant record entry
  - `UpdateApplicantRecordStatus`: Updates the review status (Todo, In Progress, etc.) for the given applicant record entry

- Updated some typeorm models and database models with createdAt column - since database insertions were failing without these columns

<!-- What should the reviewer do to verify your changes? Describe expected results and include screenshots when appropriate -->
## Steps to test
1. Test the `createReviewedApplication` mutator and `bulkCreateReviewedApplication` mutator by creating reviewed applicant record entries.
  - Visit http://localhost:5000/graphql to test queries
  - To test `createReviewedApplication`:


```
mutation {
  bulkCreateReviewedApplicantRecords(
    reviewedApplicantRecordPK: { reviewerId: "1", applicantRecordId: "2a531f06-7c6b-4f44-bdbe-6d054d0336ed" },
  ) {
    applicantRecordId
    reviewerId
    status
    review {
      passionFSG
      teamPlayer
      desireToLearn
      skill
      skillCategory
    }
  }
}
```
 
  - To test `BulkCreateReviewedApplicantRecords`:
```
mutation {
  bulkCreateReviewedApplicantRecords(
    reviewedApplicantRecordPKs: [{ reviewerId: "1", applicantRecordId: "a0bdc2aa-1abf-4e2d-89a3-44dd723ba2a7" }, { reviewerId: "2", applicantRecordId: "a0bdc2aa-1abf-4e2d-89a3-44dd723ba2a7" }]
  ) {
    applicantRecordId
    reviewerId
    status
    review {
      passionFSG
      teamPlayer
      desireToLearn
      skill
      skillCategory
    }
  }
}
```

2. Using the created entries, we can now test the update functions.
  - To test `UpdateReviewedApplicantRecordReview `:

```
mutation {
  updateReviewedApplicantRecordReview(
    reviewedApplicantRecordPK: { reviewerId: "1", applicantRecordId: "a0bdc2aa-1abf-4e2d-89a3-44dd723ba2a7" }
    review: {
      passionFSG: 0
      teamPlayer: 0
      desireToLearn: 0
      skill: 0
      skillCategory: Junior
    }
  ) {
    applicantRecordId
    reviewerId
    status
    review {
      passionFSG
      teamPlayer
      desireToLearn
      skill
      skillCategory
    }
  }
}
```

  - To test `UpdateReviewedApplicantRecordStatus`:

```
mutation {
  updateReviewedApplicantRecordStatus(
    reviewedApplicantRecordPK: { reviewerId: "1", applicantRecordId: "a0bdc2aa-1abf-4e2d-89a3-44dd723ba2a7" }
    status: "Done"
  ) {
    applicantRecordId
    reviewerId
    status
    review {
      passionFSG
      teamPlayer
      desireToLearn
      skill
      skillCategory
    }
  }
}
```


<!-- Draw attention to the substantial parts of your PR or anything you'd like a second opinion on -->
## What should reviewers focus on?
- The bulkCreateReviewedApplicantRecords mutation uses Sequelize's bulkCreate for efficiency.
    This method is much faster for large batches, but if any record fails (e.g., due to a constraint violation),
    the entire batch is rolled back and no records are created. Partial success is not possible.
  - To support partial failure (i.e., create as many records as possible and report which ones failed),
    use the createReviewedApplicantRecord mutation in a loop on the client side, or implement a service method
    that creates records individually and returns both successes and failures.


## Checklist
- [x] My PR name is descriptive and in imperative tense
- [x] My commit messages are descriptive and in imperative tense. My commits are atomic and trivial commits are squashed or fixup'd into non-trivial commits
- [x] I have run the appropriate linter(s)
- [x] I have requested a review from the PL, as well as other devs who have background knowledge on this PR or who will be building on top of this PR
