### PR TITLE
[INTF25] Migration & Model for Admin Comments

### DIFF
--- a/backend/typescript/migrations/20251004172010-create-admin-comments-table.ts
+++ b/backend/typescript/migrations/20251004172010-create-admin-comments-table.ts
@@ -1,0 +1,49 @@
+import { DataTypes } from "sequelize";
+import { Migration } from "../umzug";
+
+const TABLE_NAME = "admin_comments";
+
+export const up: Migration = async ({ context: sequelize }) => {
+  await sequelize.getQueryInterface().createTable(TABLE_NAME, {
+    id: {
+      type: DataTypes.UUID,
+      defaultValue: DataTypes.UUIDV4,
+      allowNull: false,
+      primaryKey: true,
+    },
+    userId: {
+      type: DataTypes.INTEGER,
+      allowNull: false,
+      references: {
+        model: "users",
+        key: "id",
+      },
+    },
+    applicantRecordId: {
+      type: DataTypes.STRING,
+      allowNull: false,
+      references: {
+        model: "applicant_records",
+        key: "id",
+      },
+    },
+    comment: {
+      type: DataTypes.STRING,
+      allowNull: false,
+    },
+    createdAt: {
+      type: DataTypes.DATE,
+      allowNull: false,
+      defaultValue: DataTypes.NOW,
+    },
+    updatedAt: {
+      type: DataTypes.DATE,
+      allowNull: false,
+      defaultValue: DataTypes.NOW,
+    },
+  });
+};
+
+export const down: Migration = async ({ context: sequelize }) => {
+  await sequelize.getQueryInterface().dropTable(TABLE_NAME);
+};

--- a/backend/typescript/models/adminComment.model.ts
+++ b/backend/typescript/models/adminComment.model.ts
@@ -18,11 +18,11 @@ export default class AdminComment extends Model {
   id!: string;
 
   @ForeignKey(() => User)
-  @Column({ type: DataType.INTEGER })
+  @Column({ type: DataType.INTEGER, allowNull: false })
   userId!: number;
 
   @ForeignKey(() => ApplicantRecord)
-  @Column({ type: DataType.UUID })
+  @Column({ type: DataType.UUID, allowNull: false })
   applicantRecordId!: string;
 
   @Column({ type: DataType.STRING, allowNull: false })

--- a/backend/typescript/models/adminComment.model.ts
+++ b/backend/typescript/models/adminComment.model.ts
@@ -1,0 +1,36 @@
+import {
+  Column,
+  DataType,
+  ForeignKey,
+  Model,
+  Table,
+} from "sequelize-typescript";
+import User from "./user.model";
+import ApplicantRecord from "./applicantRecord.model";
+
+@Table({ tableName: "admin_comments" })
+export default class AdminComment extends Model {
+  @Column({
+    type: DataType.UUID,
+    defaultValue: DataType.UUIDV4,
+    primaryKey: true,
+  })
+  id!: string;
+
+  @ForeignKey(() => User)
+  @Column({ type: DataType.INTEGER })
+  userId!: number;
+
+  @ForeignKey(() => ApplicantRecord)
+  @Column({ type: DataType.UUID })
+  applicantRecordId!: string;
+
+  @Column({ type: DataType.STRING, allowNull: false })
+  comment!: string;
+
+  @Column({ type: DataType.DATE, allowNull: false })
+  createdAt!: Date;
+
+  @Column({ type: DataType.DATE, allowNull: false })
+  updatedAt!: Date;
+}


### PR DESCRIPTION
## Notion ticket link
[Ticket Name](https://www.notion.so/uwblueprintexecs/Add-Admin-Comments-Table-27e10f3fb1dc80adbff5eae924241a8d?v=27710f3fb1dc818d837a000cac8f5d24&source=copy_link)


<!-- Give a quick summary of the implementation details, provide design justifications if necessary -->
## Implementation description
* `adminComment.model.ts` was created with respect to the TDD's specifications.
* A migration was created to create and delete the database table.


<!-- What should the reviewer do to verify your changes? Describe expected results and include screenshots when appropriate -->
## Steps to test
1. Clone into this branch, and run `docker exec recruitment_tools_backend node migrate up`.
2. Open pgAdmin4 and verify that you see the following results.
<img width="895" height="545" alt="image" src="https://github.com/user-attachments/assets/4a621847-1a30-4028-b6c5-f608954b174c" />
<img width="895" height="545" alt="image" src="https://github.com/user-attachments/assets/5335b80a-6f30-4f18-99de-a0a224a4674c" />


<!-- Draw attention to the substantial parts of your PR or anything you'd like a second opinion on -->
## What should reviewers focus on?
* Field types are satisfactory 
    * I would like to note that the `applicant_record` relation  saves its `id` as a string and not a UUID. This is why the migration has the foreign key as type string and not UUID.

## Checklist
- [x] My PR name is descriptive and in imperative tense
- [x] My commit messages are descriptive and in imperative tense. My commits are atomic and trivial commits are squashed or fixup'd into non-trivial commits
- [x] I have run the appropriate linter(s)
- [x] I have requested a review from the PL, as well as other devs who have background knowledge on this PR or who will be building on top of this PR
