### PR TITLE
[INTF25] Update database to support applicant flagging

### DIFF
--- a/backend/typescript/migrations/20251004172907-add-isApplicantFlagged-column-to-applicant-records-table.ts
+++ b/backend/typescript/migrations/20251004172907-add-isApplicantFlagged-column-to-applicant-records-table.ts
@@ -1,0 +1,20 @@
+import { DataType } from "sequelize-typescript";
+import { Migration } from "../umzug";
+
+const TABLE_NAME = "applicant_records";
+
+export const up: Migration = async ({ context: sequelize }) => {
+  await sequelize
+    .getQueryInterface()
+    .addColumn(TABLE_NAME, "isApplicantFlagged", {
+      type: DataType.BOOLEAN,
+      allowNull: false,
+      defaultValue: false,
+    });
+};
+
+export const down: Migration = async ({ context: sequelize }) => {
+  await sequelize
+    .getQueryInterface()
+    .removeColumn(TABLE_NAME, "isApplicantFlagged");
+};

--- a/backend/typescript/models/applicantRecord.model.ts
+++ b/backend/typescript/models/applicantRecord.model.ts
@@ -47,4 +47,7 @@ export default class ApplicantRecord extends Model {
 
   @Column({ type: DataType.JSONB, allowNull: true })
   extraInfo!: ApplicantRecordExtraInfo;
+
+  @Column({ type: DataType.BOOLEAN, defaultValue: false })
+  isApplicantFlagged!: boolean;
 }


### PR DESCRIPTION
## Notion ticket link
<!-- Please replace with your ticket's URL -->
[Update Database to Support Applicant Flagging](https://www.notion.so/uwblueprintexecs/Update-Database-to-Support-Applicant-Flagging-27e10f3fb1dc80b78e47e3cb11d6ba82?v=27710f3fb1dc818d837a000cac8f5d24&source=copy_link)


<!-- Give a quick summary of the implementation details, provide design justifications if necessary -->
## Implementation description
- Add flagging functionality for applicants to help admins bookmark candidates during the review process.
- Added `isApplicantFlagged` boolean column to `ApplicantRecord` model
- Created database migration to add the new column
- Column defaults to `false` for existing records

<img width="1392" height="465" alt="image" src="https://github.com/user-attachments/assets/3f1a1523-42b3-4da2-8f1e-bb6f26ff7bd8" />


<!-- What should the reviewer do to verify your changes? Describe expected results and include screenshots when appropriate -->
## Steps to test
1. Migration runs successfully with `docker exec recruitment_tools_backend node migrate up`
2. Column appears in database schema
3. Existing records have `isApplicantFlagged = false`
4. Migration can be rolled back with `migrate down`


<!-- Draw attention to the substantial parts of your PR or anything you'd like a second opinion on -->
## What should reviewers focus on?
* testing to see if the migration works


## Checklist
- [x] My PR name is descriptive and in imperative tense
- [x] My commit messages are descriptive and in imperative tense. My commits are atomic and trivial commits are squashed or fixup'd into non-trivial commits
- [x] I have run the appropriate linter(s)
- [x] I have requested a review from the PL, as well as other devs who have background knowledge on this PR or who will be building on top of this PR
