### PR TITLE
[INTF25] Update database to support conflict reporting

### DIFF
--- a/backend/typescript/migrations/20251004173456-add-reviewer-has-conflict-column.ts
+++ b/backend/typescript/migrations/20251004173456-add-reviewer-has-conflict-column.ts
@@ -1,0 +1,20 @@
+import { DataType } from "sequelize-typescript";
+import { Migration } from "../umzug";
+
+const TABLE_NAME = "reviewed_applicant_records";
+
+export const up: Migration = async ({ context: sequelize }) => {
+  await sequelize
+    .getQueryInterface()
+    .addColumn(TABLE_NAME, "reviewerHasConflict", {
+      type: DataType.BOOLEAN,
+      allowNull: false,
+      defaultValue: false,
+    });
+};
+
+export const down: Migration = async ({ context: sequelize }) => {
+  await sequelize
+    .getQueryInterface()
+    .removeColumn(TABLE_NAME, "reviewerHasConflict");
+};

--- a/backend/typescript/models/reviewedApplicantRecord.model.ts
+++ b/backend/typescript/models/reviewedApplicantRecord.model.ts
@@ -7,9 +7,9 @@ import {
   Model,
   Table,
 } from "sequelize-typescript";
-import User from "./user.model";
 import { Review, ReviewStatus, ReviewStatusEnum } from "../types";
 import ApplicantRecord from "./applicantRecord.model";
+import User from "./user.model";
 
 @Table({ tableName: "reviewed_applicant_records" })
 export default class ReviewedApplicantRecord extends Model {
@@ -29,4 +29,10 @@ export default class ReviewedApplicantRecord extends Model {
     defaultValue: ReviewStatusEnum.TODO,
   })
   status!: ReviewStatus;
+
+  @Column({
+    type: DataType.BOOLEAN,
+    defaultValue: false,
+  })
+  reviewerHasConflict!: boolean;
 }

--- a/backend/typescript/types.ts
+++ b/backend/typescript/types.ts
@@ -235,4 +235,5 @@ export type ReviewedApplicantRecordDTO = {
   reviewerId: number;
   review: Review;
   status: ReviewStatus;
+  reviewerHasConflict: boolean;
 };


### PR DESCRIPTION
## Notion ticket link
[Update Database to Support Conflict Reporting](https://www.notion.so/uwblueprintexecs/Update-Database-to-Support-Conflict-Reporting-27e10f3fb1dc808ca854fd5905fbe73a)

## Implementation description
* Added `reviewerHasConflict` boolean field to the `ReviewedApplicantRecord` model with default `false`
* Created migration to add this column to the Postgres schema

## Steps to test
1. Run `docker exec recruitment_tools_backend node migrate up`
2. Verify that the `reviewed_applicant_records` table now includes the `reviewerHasConflict` column (type: boolean, default: false)

## What should reviewers focus on?
* Correctness of the migration script


## Checklist
- [x] My PR name is descriptive and in imperative tense
- [x] My commit messages are descriptive and in present tense
- [x] I have run the appropriate linter(s)
- [x] I have requested a review from the PL and relevant devs