### PR TITLE
[INTW26] Add isArchived to positions and isActive to users

### DIFF
--- a/backend/typescript/migrations/20260211120000-add-isArchived-and-isActive-columns.ts
+++ b/backend/typescript/migrations/20260211120000-add-isArchived-and-isActive-columns.ts
@@ -5,11 +5,13 @@ const POSITIONS_TABLE_NAME = "positions";
 const USERS_TABLE_NAME = "users";
 
 export const up: Migration = async ({ context: sequelize }) => {
-  await sequelize.getQueryInterface().addColumn(POSITIONS_TABLE_NAME, "isArchived", {
-    type: DataType.BOOLEAN,
-    allowNull: false,
-    defaultValue: false,
-  });
+  await sequelize
+    .getQueryInterface()
+    .addColumn(POSITIONS_TABLE_NAME, "isArchived", {
+      type: DataType.BOOLEAN,
+      allowNull: false,
+      defaultValue: false,
+    });
 
   await sequelize.getQueryInterface().addColumn(USERS_TABLE_NAME, "isActive", {
     type: DataType.BOOLEAN,
@@ -19,9 +21,10 @@ export const up: Migration = async ({ context: sequelize }) => {
 };
 
 export const down: Migration = async ({ context: sequelize }) => {
-  await sequelize.getQueryInterface().removeColumn(USERS_TABLE_NAME, "isActive");
+  await sequelize
+    .getQueryInterface()
+    .removeColumn(USERS_TABLE_NAME, "isActive");
   await sequelize
     .getQueryInterface()
     .removeColumn(POSITIONS_TABLE_NAME, "isArchived");
 };
-

--- a/backend/typescript/migrations/20260211120000-add-isArchived-and-isActive-columns.ts
+++ b/backend/typescript/migrations/20260211120000-add-isArchived-and-isActive-columns.ts
@@ -1,0 +1,27 @@
+import { DataType } from "sequelize-typescript";
+import { Migration } from "../umzug";
+
+const POSITIONS_TABLE_NAME = "positions";
+const USERS_TABLE_NAME = "users";
+
+export const up: Migration = async ({ context: sequelize }) => {
+  await sequelize.getQueryInterface().addColumn(POSITIONS_TABLE_NAME, "isArchived", {
+    type: DataType.BOOLEAN,
+    allowNull: false,
+    defaultValue: false,
+  });
+
+  await sequelize.getQueryInterface().addColumn(USERS_TABLE_NAME, "isActive", {
+    type: DataType.BOOLEAN,
+    allowNull: false,
+    defaultValue: true,
+  });
+};
+
+export const down: Migration = async ({ context: sequelize }) => {
+  await sequelize.getQueryInterface().removeColumn(USERS_TABLE_NAME, "isActive");
+  await sequelize
+    .getQueryInterface()
+    .removeColumn(POSITIONS_TABLE_NAME, "isArchived");
+};
+

--- a/backend/typescript/models/position.model.ts
+++ b/backend/typescript/models/position.model.ts
@@ -7,4 +7,7 @@ export default class Position extends Model {
 
   @Column({ type: DataType.STRING })
   department!: string;
+
+  @Column({ type: DataType.BOOLEAN, defaultValue: false })
+  isArchived!: boolean;
 }

--- a/backend/typescript/models/user.model.ts
+++ b/backend/typescript/models/user.model.ts
@@ -37,6 +37,9 @@ export default class User extends Model {
   @Column({ type: DataType.STRING })
   position?: string;
 
+  @Column({ type: DataType.BOOLEAN, defaultValue: true })
+  isActive!: boolean;
+
   @HasMany(() => ReviewedApplicantRecord, {
     foreignKey: "reviewerId",
     sourceKey: "id",


### PR DESCRIPTION
## Notion ticket link
[Update Positions and Users Table  to Support Archived Positions](https://www.notion.so/uwblueprintexecs/Update-Positions-and-Users-Table-to-Support-Archived-Positions-30010f3fb1dc80e683e5c02d61af5535?v=6b710f3fb1dc83d7b43d08147fd183be&source=copy_link)

## Implementation description
* Added `positions.isArchived` (boolean, NOT NULL, default `false`) via migration and Sequelize model.
* Added `users.isActive` (boolean, NOT NULL, default `true`) via migration and Sequelize model.

## Steps to test
1. Run `docker exec recruitment_tools_backend node migrate up`.
2. Verify `positions` has `isArchived boolean not null default false` (e.g. `\d positions`).
3. Verify `users` has `isActive boolean not null default true` (e.g. `\d users`).

## What should reviewers focus on?
* Migration correctness (defaults + NOT NULL) and model parity.