### PR TITLE
[INTW26] Build CRUD Endpoints for Interview Delegations

### DIFF
--- a/backend/typescript/graphql/index.ts
+++ b/backend/typescript/graphql/index.ts
@@ -27,6 +27,8 @@ import reviewPageType from "./types/reviewPageType";
 import reviewPageResolvers from "./resolvers/reviewPageResolvers";
 import interviewedApplicantRecordsTypes from "./types/interviewedApplicantRecordsTypes";
 import interviewedApplicantRecordsResolvers from "./resolvers/interviewedApplicantRecordsResolvers";
+import interviewDelegationsTypes from "./types/interviewDelegationsTypes";
+import interviewDelegationsResolvers from "./resolvers/interviewDelegationsResolvers";
 
 const query = gql`
   type Query {
@@ -53,6 +55,7 @@ const executableSchema = makeExecutableSchema({
     adminCommentType,
     applicantRecordType,
     reviewPageType,
+    interviewDelegationsTypes,
     reviewedApplicantRecordTypes,
     interviewedApplicantRecordsTypes,
   ],
@@ -66,6 +69,7 @@ const executableSchema = makeExecutableSchema({
     adminCommentResolvers,
     applicantRecordResolvers,
     reviewPageResolvers,
+    interviewDelegationsResolvers,
     reviewedApplicantRecordResolvers,
     interviewedApplicantRecordsResolvers,
   ),
@@ -87,6 +91,7 @@ const graphQLMiddlewares = {
     users: authorizedByAdmin(),
     adminCommentsByApplicantRecordId: authorizedByAdmin(),
     adminCommentById: authorizedByAdmin(),
+    getInterviewDelegation: authorizedByAllRoles(),
   },
   Mutation: {
     createEntity: authorizedByAllRoles(),
@@ -110,6 +115,11 @@ const graphQLMiddlewares = {
     createAdminComment: authorizedByAdmin(),
     updateAdminComment: authorizedByAdmin(),
     deleteAdminCommentById: authorizedByAdmin(),
+    createInterviewDelegation: authorizedByAllRoles(),
+    updateInterviewDelegation: authorizedByAllRoles(),
+    deleteInterviewDelegation: authorizedByAllRoles(),
+    bulkCreateInterviewDelegations: authorizedByAllRoles(),
+    bulkDeleteInterviewDelegations: authorizedByAllRoles(),
   },
 };
 

--- a/backend/typescript/graphql/resolvers/interviewDelegationsResolvers.ts
+++ b/backend/typescript/graphql/resolvers/interviewDelegationsResolvers.ts
@@ -1,0 +1,105 @@
+import InterviewDelegationsService from "../../services/implementations/interviewDelegationsService";
+import IInterviewDelegationsService from "../../services/interfaces/IInterviewDelegationsService";
+import {
+  CreateInterviewDelegationDTO,
+  DeleteInterviewDelegationDTO,
+  InterviewDelegationDTO,
+} from "../../types";
+import { getErrorMessage } from "../../utilities/errorUtils";
+
+const interviewDelegationsService: IInterviewDelegationsService =
+  new InterviewDelegationsService();
+
+const interviewDelegationsResolvers = {
+  Query: {
+    getInterviewDelegation: async (
+      _parent: undefined,
+      args: { interviewedApplicantRecordId: string; interviewerId: number },
+    ): Promise<InterviewDelegationDTO> => {
+      try {
+        return await interviewDelegationsService.getInterviewDelegation(
+          args.interviewedApplicantRecordId,
+          args.interviewerId,
+        );
+      } catch (error) {
+        throw new Error(getErrorMessage(error));
+      }
+    },
+  },
+  Mutation: {
+    createInterviewDelegation: async (
+      _parent: undefined,
+      args: { interviewedApplicantRecordId: string; interviewerId: number },
+    ): Promise<InterviewDelegationDTO> => {
+      try {
+        return await interviewDelegationsService.createInterviewDelegation(
+          args.interviewedApplicantRecordId,
+          args.interviewerId,
+        );
+      } catch (error) {
+        throw new Error(getErrorMessage(error));
+      }
+    },
+
+    updateInterviewDelegation: async (
+      _parent: undefined,
+      args: {
+        interviewedApplicantRecordId: string;
+        prevInterviewerId: number;
+        newInterviewerId: number;
+      },
+    ): Promise<InterviewDelegationDTO> => {
+      try {
+        return await interviewDelegationsService.updateInterviewDelegation(
+          args.interviewedApplicantRecordId,
+          args.prevInterviewerId,
+          args.newInterviewerId,
+        );
+      } catch (error) {
+        throw new Error(getErrorMessage(error));
+      }
+    },
+
+    deleteInterviewDelegation: async (
+      _parent: undefined,
+      args: { interviewedApplicantRecordId: string; interviewerId: number },
+    ): Promise<InterviewDelegationDTO> => {
+      try {
+        return await interviewDelegationsService.deleteInterviewDelegation(
+          args.interviewedApplicantRecordId,
+          args.interviewerId,
+        );
+      } catch (error) {
+        throw new Error(getErrorMessage(error));
+      }
+    },
+
+    bulkCreateInterviewDelegations: async (
+      _parent: undefined,
+      args: { delegations: CreateInterviewDelegationDTO[] },
+    ): Promise<InterviewDelegationDTO[]> => {
+      try {
+        return await interviewDelegationsService.bulkCreateInterviewDelegations(
+          args.delegations,
+        );
+      } catch (error) {
+        throw new Error(getErrorMessage(error));
+      }
+    },
+
+    bulkDeleteInterviewDelegations: async (
+      _parent: undefined,
+      args: { delegations: DeleteInterviewDelegationDTO[] },
+    ): Promise<InterviewDelegationDTO[]> => {
+      try {
+        return await interviewDelegationsService.bulkDeleteInterviewDelegations(
+          args.delegations,
+        );
+      } catch (error) {
+        throw new Error(getErrorMessage(error));
+      }
+    },
+  },
+};
+
+export default interviewDelegationsResolvers;

--- a/backend/typescript/graphql/resolvers/interviewDelegationsResolvers.ts
+++ b/backend/typescript/graphql/resolvers/interviewDelegationsResolvers.ts
@@ -29,12 +29,17 @@ const interviewDelegationsResolvers = {
   Mutation: {
     createInterviewDelegation: async (
       _parent: undefined,
-      args: { interviewedApplicantRecordId: string; interviewerId: number },
+      args: {
+        interviewedApplicantRecordId: string;
+        interviewerId: number;
+        groupId: string;
+      },
     ): Promise<InterviewDelegationDTO> => {
       try {
         return await interviewDelegationsService.createInterviewDelegation(
           args.interviewedApplicantRecordId,
           args.interviewerId,
+          args.groupId,
         );
       } catch (error) {
         throw new Error(getErrorMessage(error));
@@ -47,6 +52,7 @@ const interviewDelegationsResolvers = {
         interviewedApplicantRecordId: string;
         prevInterviewerId: number;
         newInterviewerId: number;
+        groupId: string;
       },
     ): Promise<InterviewDelegationDTO> => {
       try {
@@ -54,6 +60,7 @@ const interviewDelegationsResolvers = {
           args.interviewedApplicantRecordId,
           args.prevInterviewerId,
           args.newInterviewerId,
+          args.groupId,
         );
       } catch (error) {
         throw new Error(getErrorMessage(error));

--- a/backend/typescript/graphql/types/interviewDelegationsTypes.ts
+++ b/backend/typescript/graphql/types/interviewDelegationsTypes.ts
@@ -1,0 +1,61 @@
+import { gql } from "apollo-server-express";
+
+const interviewDelegationsTypes = gql`
+  enum InterviewConflict {
+    APPLICANT_CONFLICT
+    APPLICANT_NO_RESPONSE
+    PARTNER_NO_RESPONSE
+    CANNOT_ATTEND
+  }
+
+  type InterviewDelegation {
+    interviewedApplicantRecordId: ID!
+    interviewerId: Int!
+    interviewHasConflict: InterviewConflict
+  }
+
+  input BulkCreateInterviewDelegationInput {
+    interviewedApplicantRecordId: ID!
+    interviewerId: Int!
+  }
+
+  input BulkDeleteInterviewDelegationInput {
+    interviewedApplicantRecordId: ID!
+    interviewerId: Int!
+  }
+
+  extend type Query {
+    getInterviewDelegation(
+      interviewedApplicantRecordId: ID!
+      interviewerId: Int!
+    ): InterviewDelegation!
+  }
+
+  extend type Mutation {
+    createInterviewDelegation(
+      interviewedApplicantRecordId: ID!
+      interviewerId: Int!
+    ): InterviewDelegation!
+
+    updateInterviewDelegation(
+      interviewedApplicantRecordId: ID!
+      prevInterviewerId: Int!
+      newInterviewerId: Int!
+    ): InterviewDelegation!
+
+    deleteInterviewDelegation(
+      interviewedApplicantRecordId: ID!
+      interviewerId: Int!
+    ): InterviewDelegation!
+
+    bulkCreateInterviewDelegations(
+      delegations: [BulkCreateInterviewDelegationInput!]!
+    ): [InterviewDelegation!]!
+
+    bulkDeleteInterviewDelegations(
+      delegations: [BulkDeleteInterviewDelegationInput!]!
+    ): [InterviewDelegation!]!
+  }
+`;
+
+export default interviewDelegationsTypes;

--- a/backend/typescript/graphql/types/interviewDelegationsTypes.ts
+++ b/backend/typescript/graphql/types/interviewDelegationsTypes.ts
@@ -17,6 +17,7 @@ const interviewDelegationsTypes = gql`
   input BulkCreateInterviewDelegationInput {
     interviewedApplicantRecordId: ID!
     interviewerId: Int!
+    groupId: ID!
   }
 
   input BulkDeleteInterviewDelegationInput {
@@ -35,12 +36,14 @@ const interviewDelegationsTypes = gql`
     createInterviewDelegation(
       interviewedApplicantRecordId: ID!
       interviewerId: Int!
+      groupId: ID!
     ): InterviewDelegation!
 
     updateInterviewDelegation(
       interviewedApplicantRecordId: ID!
       prevInterviewerId: Int!
       newInterviewerId: Int!
+      groupId: ID!
     ): InterviewDelegation!
 
     deleteInterviewDelegation(

--- a/backend/typescript/graphql/types/interviewDelegationsTypes.ts
+++ b/backend/typescript/graphql/types/interviewDelegationsTypes.ts
@@ -12,6 +12,7 @@ const interviewDelegationsTypes = gql`
     interviewedApplicantRecordId: ID!
     interviewerId: Int!
     interviewHasConflict: InterviewConflict
+    groupId: ID!
   }
 
   input BulkCreateInterviewDelegationInput {

--- a/backend/typescript/migrations/20260302002547-add-interview-delegation-timestamp-columns.ts
+++ b/backend/typescript/migrations/20260302002547-add-interview-delegation-timestamp-columns.ts
@@ -1,0 +1,23 @@
+import { DataType } from "sequelize-typescript";
+import { Migration } from "../umzug";
+
+const TABLE_NAME = "interview_delegations";
+
+export const up: Migration = async ({ context: sequelize }) => {
+  await sequelize.getQueryInterface().addColumn(TABLE_NAME, "createdAt", {
+    type: DataType.DATE,
+    allowNull: false,
+    defaultValue: DataType.NOW,
+  });
+
+  await sequelize.getQueryInterface().addColumn(TABLE_NAME, "updatedAt", {
+    type: DataType.DATE,
+    allowNull: false,
+    defaultValue: DataType.NOW,
+  });
+};
+
+export const down: Migration = async ({ context: sequelize }) => {
+  await sequelize.getQueryInterface().removeColumn(TABLE_NAME, "createdAt");
+  await sequelize.getQueryInterface().removeColumn(TABLE_NAME, "updatedAt");
+};

--- a/backend/typescript/migrations/20260325220421-change-interview-group-scheduling-link-to-nullable.ts
+++ b/backend/typescript/migrations/20260325220421-change-interview-group-scheduling-link-to-nullable.ts
@@ -1,0 +1,23 @@
+import { DataType } from "sequelize-typescript";
+import { Migration } from "../umzug";
+
+const TABLE_NAME = "interview_groups";
+
+export const up: Migration = async ({ context: sequelize }) => {
+  await sequelize
+    .getQueryInterface()
+    .changeColumn(TABLE_NAME, "schedulingLink", {
+      type: DataType.STRING,
+      allowNull: true,
+      defaultValue: null,
+    });
+};
+
+export const down: Migration = async ({ context: sequelize }) => {
+  await sequelize
+    .getQueryInterface()
+    .changeColumn(TABLE_NAME, "schedulingLink", {
+      type: DataType.STRING,
+      allowNull: false,
+    });
+};

--- a/backend/typescript/models/interviewDelegation.model.ts
+++ b/backend/typescript/models/interviewDelegation.model.ts
@@ -37,6 +37,20 @@ export default class InterviewDelegation extends Model {
   })
   interviewHasConflict?: InterviewConflict;
 
+  @Column({
+    type: DataType.DATE,
+    allowNull: false,
+    defaultValue: DataType.NOW,
+  })
+  createdAt!: Date;
+
+  @Column({
+    type: DataType.DATE,
+    allowNull: false,
+    defaultValue: DataType.NOW,
+  })
+  updatedAt!: Date;
+
   @BelongsTo(() => InterviewedApplicantRecord, {
     foreignKey: "interviewedApplicantRecordId",
     targetKey: "id",

--- a/backend/typescript/services/implementations/interviewDelegationsService.ts
+++ b/backend/typescript/services/implementations/interviewDelegationsService.ts
@@ -1,0 +1,195 @@
+import { sequelize } from "../../models";
+import InterviewDelegation from "../../models/interviewDelegation.model";
+import {
+  CreateInterviewDelegationDTO,
+  DeleteInterviewDelegationDTO,
+  InterviewDelegationDTO,
+} from "../../types";
+import { getErrorMessage } from "../../utilities/errorUtils";
+import logger from "../../utilities/logger";
+import IInterviewDelegationsService from "../interfaces/IInterviewDelegationsService";
+
+const Logger = logger(__filename);
+
+function toInterviewDelegationDTO(
+  delegation: InterviewDelegation,
+): InterviewDelegationDTO {
+  return {
+    interviewedApplicantRecordId: delegation.interviewedApplicantRecordId,
+    interviewerId: delegation.interviewerId,
+    interviewHasConflict: delegation.interviewHasConflict,
+  };
+}
+
+class InterviewDelegationsService implements IInterviewDelegationsService {
+  /* eslint-disable class-methods-use-this */
+  async createInterviewDelegation(
+    interviewedApplicantRecordId: string,
+    interviewerId: number,
+  ): Promise<InterviewDelegationDTO> {
+    try {
+      const newDelegation = await InterviewDelegation.create({
+        interviewedApplicantRecordId,
+        interviewerId,
+      });
+      return toInterviewDelegationDTO(newDelegation);
+    } catch (error: unknown) {
+      Logger.error(
+        `Failed to create interview delegation. Reason = ${getErrorMessage(
+          error,
+        )}`,
+      );
+      throw error;
+    }
+  }
+
+  // Note: endpoint should delete existing record and create new record in one transaction.
+  async updateInterviewDelegation(
+    interviewedApplicantRecordId: string,
+    prevInterviewerId: number,
+    newInterviewerId: number,
+  ): Promise<InterviewDelegationDTO> {
+    try {
+      const updatedDelegation = await sequelize.transaction(async (t) => {
+        const existingDelegation = await InterviewDelegation.findOne({
+          where: {
+            interviewedApplicantRecordId,
+            interviewerId: prevInterviewerId,
+          },
+          transaction: t,
+        });
+        if (!existingDelegation) {
+          throw new Error(
+            `Interview delegation not found for interviewedApplicantRecordId: ${interviewedApplicantRecordId} and interviewerId: ${prevInterviewerId}`,
+          );
+        }
+        await existingDelegation.destroy({ transaction: t });
+        return InterviewDelegation.create(
+          {
+            interviewedApplicantRecordId,
+            interviewerId: newInterviewerId,
+          },
+          { transaction: t },
+        );
+      });
+      return toInterviewDelegationDTO(updatedDelegation);
+    } catch (error: unknown) {
+      Logger.error(
+        `Failed to update interview delegation. Reason = ${getErrorMessage(
+          error,
+        )}`,
+      );
+      throw error;
+    }
+  }
+
+  async getInterviewDelegation(
+    interviewedApplicantRecordId: string,
+    interviewerId: number,
+  ): Promise<InterviewDelegationDTO> {
+    try {
+      const delegation = await InterviewDelegation.findOne({
+        where: { interviewedApplicantRecordId, interviewerId },
+      });
+      if (!delegation) {
+        throw new Error(
+          `No interview delegation found for interviewedApplicantRecordId: ${interviewedApplicantRecordId} and interviewerId: ${interviewerId}`,
+        );
+      }
+      return toInterviewDelegationDTO(delegation);
+    } catch (error: unknown) {
+      Logger.error(
+        `Failed to fetch interview delegation. Reason = ${getErrorMessage(
+          error,
+        )}`,
+      );
+      throw error;
+    }
+  }
+
+  async deleteInterviewDelegation(
+    interviewedApplicantRecordId: string,
+    interviewerId: number,
+  ): Promise<InterviewDelegationDTO> {
+    try {
+      const delegation = await InterviewDelegation.findOne({
+        where: { interviewedApplicantRecordId, interviewerId },
+      });
+      if (!delegation) {
+        throw new Error(
+          `No interview delegation found for interviewedApplicantRecordId: ${interviewedApplicantRecordId} and interviewerId: ${interviewerId}`,
+        );
+      }
+      await delegation.destroy();
+      return toInterviewDelegationDTO(delegation);
+    } catch (error: unknown) {
+      Logger.error(
+        `Failed to delete interview delegation. Reason = ${getErrorMessage(
+          error,
+        )}`,
+      );
+      throw error;
+    }
+  }
+
+  async bulkCreateInterviewDelegations(
+    delegations: CreateInterviewDelegationDTO[],
+  ): Promise<InterviewDelegationDTO[]> {
+    try {
+      const createdDelegations = await sequelize.transaction(async (t) => {
+        const delegationRows = await InterviewDelegation.bulkCreate(
+          delegations,
+          { transaction: t },
+        );
+        return delegationRows;
+      });
+      return createdDelegations.map(toInterviewDelegationDTO);
+    } catch (error: unknown) {
+      Logger.error(
+        `Failed to bulk create interview delegations. Reason = ${getErrorMessage(
+          error,
+        )}`,
+      );
+      throw error;
+    }
+  }
+
+  async bulkDeleteInterviewDelegations(
+    delegations: DeleteInterviewDelegationDTO[],
+  ): Promise<InterviewDelegationDTO[]> {
+    try {
+      const deletedDelegations = await sequelize.transaction(async (t) => {
+        const foundDelegations = await Promise.all(
+          delegations.map(({ interviewedApplicantRecordId, interviewerId }) =>
+            InterviewDelegation.findOne({
+              where: { interviewedApplicantRecordId, interviewerId },
+              transaction: t,
+            }),
+          ),
+        );
+
+        if (foundDelegations.some((d) => !d)) {
+          throw new Error("Not all delegations were found, bulk delete failed");
+        }
+
+        const existingDelegations = foundDelegations as InterviewDelegation[];
+        await Promise.all(
+          existingDelegations.map((d) => d.destroy({ transaction: t })),
+        );
+
+        return existingDelegations;
+      });
+
+      return deletedDelegations.map(toInterviewDelegationDTO);
+    } catch (error: unknown) {
+      Logger.error(
+        `Failed to bulk delete interview delegations. Reason = ${getErrorMessage(
+          error,
+        )}`,
+      );
+      throw error;
+    }
+  }
+}
+
+export default InterviewDelegationsService;

--- a/backend/typescript/services/implementations/interviewDelegationsService.ts
+++ b/backend/typescript/services/implementations/interviewDelegationsService.ts
@@ -17,6 +17,7 @@ function toInterviewDelegationDTO(
   return {
     interviewedApplicantRecordId: delegation.interviewedApplicantRecordId,
     interviewerId: delegation.interviewerId,
+    groupId: delegation.groupId,
     interviewHasConflict: delegation.interviewHasConflict,
   };
 }

--- a/backend/typescript/services/implementations/interviewDelegationsService.ts
+++ b/backend/typescript/services/implementations/interviewDelegationsService.ts
@@ -27,11 +27,13 @@ class InterviewDelegationsService implements IInterviewDelegationsService {
   async createInterviewDelegation(
     interviewedApplicantRecordId: string,
     interviewerId: number,
+    groupId: string,
   ): Promise<InterviewDelegationDTO> {
     try {
       const newDelegation = await InterviewDelegation.create({
         interviewedApplicantRecordId,
         interviewerId,
+        groupId,
       });
       return toInterviewDelegationDTO(newDelegation);
     } catch (error: unknown) {
@@ -49,6 +51,7 @@ class InterviewDelegationsService implements IInterviewDelegationsService {
     interviewedApplicantRecordId: string,
     prevInterviewerId: number,
     newInterviewerId: number,
+    groupId: string,
   ): Promise<InterviewDelegationDTO> {
     try {
       const updatedDelegation = await sequelize.transaction(async (t) => {
@@ -69,6 +72,7 @@ class InterviewDelegationsService implements IInterviewDelegationsService {
           {
             interviewedApplicantRecordId,
             interviewerId: newInterviewerId,
+            groupId,
           },
           { transaction: t },
         );

--- a/backend/typescript/services/interfaces/IInterviewDelegationsService.ts
+++ b/backend/typescript/services/interfaces/IInterviewDelegationsService.ts
@@ -1,0 +1,67 @@
+import {
+  CreateInterviewDelegationDTO,
+  DeleteInterviewDelegationDTO,
+  InterviewDelegationDTO,
+} from "../../types";
+
+interface IInterviewDelegationsService {
+  /**
+   * Creates a new interview delegation record assigning an interviewer to an interviewed applicant.
+   * @param interviewedApplicantRecordId FK to the interviewed applicant record
+   * @param interviewerId FK to the user assigned as interviewer
+   */
+  createInterviewDelegation(
+    interviewedApplicantRecordId: string,
+    interviewerId: number,
+  ): Promise<InterviewDelegationDTO>;
+
+  /**
+   * Updates an existing interview delegation by deleting the old record and creating a new one in a single transaction.
+   * @param interviewedApplicantRecordId FK to the interviewed applicant record
+   * @param prevInterviewerId FK to the interviewer being replaced
+   * @param newInterviewerId FK to the new interviewer being assigned
+   */
+  updateInterviewDelegation(
+    interviewedApplicantRecordId: string,
+    prevInterviewerId: number,
+    newInterviewerId: number,
+  ): Promise<InterviewDelegationDTO>;
+
+  /**
+   * Fetches a single interview delegation record.
+   * @param interviewedApplicantRecordId FK to the interviewed applicant record
+   * @param interviewerId FK to the interviewer
+   */
+  getInterviewDelegation(
+    interviewedApplicantRecordId: string,
+    interviewerId: number,
+  ): Promise<InterviewDelegationDTO>;
+
+  /**
+   * Deletes a single interview delegation record.
+   * @param interviewedApplicantRecordId FK to the interviewed applicant record
+   * @param interviewerId FK to the interviewer
+   */
+  deleteInterviewDelegation(
+    interviewedApplicantRecordId: string,
+    interviewerId: number,
+  ): Promise<InterviewDelegationDTO>;
+
+  /**
+   * Bulk creates interview delegation records, used when running the delegations algorithm.
+   * @param delegations Array of interviewedApplicantRecordId and interviewerId tuples
+   */
+  bulkCreateInterviewDelegations(
+    delegations: CreateInterviewDelegationDTO[],
+  ): Promise<InterviewDelegationDTO[]>;
+
+  /**
+   * Bulk deletes interview delegation records.
+   * @param delegations Array of interviewedApplicantRecordId and interviewerId tuples
+   */
+  bulkDeleteInterviewDelegations(
+    delegations: DeleteInterviewDelegationDTO[],
+  ): Promise<InterviewDelegationDTO[]>;
+}
+
+export default IInterviewDelegationsService;

--- a/backend/typescript/services/interfaces/IInterviewDelegationsService.ts
+++ b/backend/typescript/services/interfaces/IInterviewDelegationsService.ts
@@ -9,10 +9,12 @@ interface IInterviewDelegationsService {
    * Creates a new interview delegation record assigning an interviewer to an interviewed applicant.
    * @param interviewedApplicantRecordId FK to the interviewed applicant record
    * @param interviewerId FK to the user assigned as interviewer
+   * @param groupId FK to the interview group this delegation belongs to
    */
   createInterviewDelegation(
     interviewedApplicantRecordId: string,
     interviewerId: number,
+    groupId: string,
   ): Promise<InterviewDelegationDTO>;
 
   /**
@@ -20,11 +22,13 @@ interface IInterviewDelegationsService {
    * @param interviewedApplicantRecordId FK to the interviewed applicant record
    * @param prevInterviewerId FK to the interviewer being replaced
    * @param newInterviewerId FK to the new interviewer being assigned
+   * @param groupId FK to the interview group this delegation belongs to
    */
   updateInterviewDelegation(
     interviewedApplicantRecordId: string,
     prevInterviewerId: number,
     newInterviewerId: number,
+    groupId: string,
   ): Promise<InterviewDelegationDTO>;
 
   /**

--- a/backend/typescript/types.ts
+++ b/backend/typescript/types.ts
@@ -335,3 +335,13 @@ export type InterviewDelegationDTO = {
   interviewHasConflict?: InterviewConflict;
   interviewGroupId: string;
 };
+
+export type CreateInterviewDelegationDTO = Omit<
+  InterviewDelegationDTO,
+  "interviewHasConflict"
+>;
+
+export type DeleteInterviewDelegationDTO = Omit<
+  InterviewDelegationDTO,
+  "interviewHasConflict"
+>;

--- a/backend/typescript/types.ts
+++ b/backend/typescript/types.ts
@@ -333,7 +333,7 @@ export type InterviewDelegationDTO = {
   interviewedApplicantRecordId: string;
   interviewerId: number;
   interviewHasConflict?: InterviewConflict;
-  interviewGroupId: string;
+  groupId: string;
 };
 
 export type CreateInterviewDelegationDTO = Omit<

--- a/backend/typescript/types.ts
+++ b/backend/typescript/types.ts
@@ -341,7 +341,7 @@ export type CreateInterviewDelegationDTO = Omit<
   "interviewHasConflict"
 >;
 
-export type DeleteInterviewDelegationDTO = Omit<
-  InterviewDelegationDTO,
-  "interviewHasConflict"
->;
+export type DeleteInterviewDelegationDTO = {
+  interviewedApplicantRecordId: string;
+  interviewerId: number;
+};


### PR DESCRIPTION
## Notion ticket link
<!-- Please replace with your ticket's URL -->
[Build CRUD Endpoints for Interview Delegations](https://www.notion.so/uwblueprintexecs/Build-CRUD-Endpoints-for-Interview-Delegations-30e10f3fb1dc806fa42dfe26bed11767?v=6b710f3fb1dc83d7b43d08147fd183be&source=copy_link)


<!-- Give a quick summary of the implementation details, provide design justifications if necessary -->
## Implementation description
* Add service functions, resolves, and graphql types to implement crud endpoints for interviewed applicant records


<!-- What should the reviewer do to verify your changes? Describe expected results and include screenshots when appropriate -->
## Steps to test
1.  Open pgAdmin and pick a random row from table `applicant_records`, copy the `id` column value
2. Insert a row into `interviewed_applicant_records` with the following query
```sql
INSERT INTO interviewed_applicant_records ("id", "applicantRecordId", "status", "createdAt", "updatedAt")
VALUES ('a0eebc99-9c0b-4ef8-bb6d-6bb9bd380a11', '<id from applicant_records>', 'NeedsReview', NOW(), NOW());
```
3. Insert a row into `interview_groups` with the following query
```sql
INSERT INTO public.interview_groups (id, status,
"schedulingLink", "createdAt", "updatedAt")
VALUES (
'a1b2c3d4-e5f6-7890-abcd-ef1234567890',
'Availability Pending',
NULL,
NOW(),
NOW()
)
RETURNING id;
```
4. In http://localhost:5000/graphql, ensure the following mutations and queries work in order:
```graphql
mutation CreateInterviewDelegation {
    createInterviewDelegation(
        interviewedApplicantRecordId: "a0eebc99-9c0b-4ef8-bb6d-6bb9bd380a11"
        interviewerId: 1
        groupId: "a1b2c3d4-e5f6-7890-abcd-ef1234567890"
    ) {
        interviewedApplicantRecordId
        interviewerId
        interviewHasConflict
        groupId
    }
}
```
```graphql
mutation UpdateInterviewDelegation {
    updateInterviewDelegation(
        interviewedApplicantRecordId: "a0eebc99-9c0b-4ef8-bb6d-6bb9bd380a11"
        prevInterviewerId: 1
        newInterviewerId: 2
        groupId: "a1b2c3d4-e5f6-7890-abcd-ef1234567890"
    ) {
        interviewedApplicantRecordId
        interviewerId
        interviewHasConflict
        groupId
    }
}
```
```graphql
query GetInterviewDelegation {
    getInterviewDelegation(
        interviewedApplicantRecordId: "a0eebc99-9c0b-4ef8-bb6d-6bb9bd380a11"
        interviewerId: 2
    ) {
        interviewedApplicantRecordId
        interviewerId
        interviewHasConflict
        groupId
    }
}
```
```graphql
mutation DeleteInterviewDelegation {
    deleteInterviewDelegation(
        interviewedApplicantRecordId: "a0eebc99-9c0b-4ef8-bb6d-6bb9bd380a11"
        interviewerId: 2
    ) {
        interviewedApplicantRecordId
        interviewerId
        interviewHasConflict
        groupId
    }
}
```
```graphql
mutation BulkCreateInterviewDelegations($delegations: [BulkCreateInterviewDelegationInput!]!) {
  bulkCreateInterviewDelegations(delegations: $delegations) {
    interviewedApplicantRecordId
    interviewerId
    interviewHasConflict
    groupId
  }
}

# use below as the query variables
{
  "delegations": [
    {
      "interviewedApplicantRecordId": "a0eebc99-9c0b-4ef8-bb6d-6bb9bd380a11",
      "interviewerId": 1,
      "groupId": "a1b2c3d4-e5f6-7890-abcd-ef1234567890"
    },
    {
      "interviewedApplicantRecordId": "a0eebc99-9c0b-4ef8-bb6d-6bb9bd380a11",
      "interviewerId": 2,
      "groupId": "a1b2c3d4-e5f6-7890-abcd-ef1234567890"
    },
    {
      "interviewedApplicantRecordId": "a0eebc99-9c0b-4ef8-bb6d-6bb9bd380a11",
      "interviewerId": 3,
      "groupId": "a1b2c3d4-e5f6-7890-abcd-ef1234567890"
    }
  ]
}
```
```graphql
mutation BulkDeleteInterviewDelegations($delegations: [BulkDeleteInterviewDelegationInput!]!) {
  bulkDeleteInterviewDelegations(delegations: $delegations) {
    interviewedApplicantRecordId
    interviewerId
    interviewHasConflict
    groupId
  }
}

# use below as query variables
{
  "delegations": [
    {
      "interviewedApplicantRecordId": "a0eebc99-9c0b-4ef8-bb6d-6bb9bd380a11",
      "interviewerId": 1
    },
    {
      "interviewedApplicantRecordId": "a0eebc99-9c0b-4ef8-bb6d-6bb9bd380a11",
      "interviewerId": 2
    },
    {
      "interviewedApplicantRecordId": "a0eebc99-9c0b-4ef8-bb6d-6bb9bd380a11",
      "interviewerId": 3
    }
  ]
}
```


<!-- Draw attention to the substantial parts of your PR or anything you'd like a second opinion on -->
## What should reviewers focus on?
* Db row and endpoint return values match with the endpoints called and the args passed
* Trying to create multiple interview delegations with the same interviewedApplicantRecordId and interviewerId (either by calling CreateInterviewDelegation with the same args multiple times or having duplicate items in the delegations list passed to BulkCreateInterviewDelegations) should result in validation error


## Checklist
- [x] My PR name is descriptive and in imperative tense
- [x] My commit messages are descriptive and in imperative tense. My commits are atomic and trivial commits are squashed or fixup'd into non-trivial commits
- [x] I have run the appropriate linter(s)
- [x] I have requested a review from the PL, as well as other devs who have background knowledge on this PR or who will be building on top of this PR
