### PR TITLE
Delete ReviewedApplicantRecordDTO from reviewDashboardType

### DIFF
--- a/backend/typescript/graphql/types/reviewDashboardType.ts
+++ b/backend/typescript/graphql/types/reviewDashboardType.ts
@@ -25,15 +25,6 @@ const reviewDashboardType = gql`
     totalScore: Int
   }
 
-  type ReviewedApplicantRecordDTO {
-    applicantRecordId: String!
-    reviewerId: Int!
-    review: Review
-    status: String!
-    score: Int
-    reviewerHasConflict: Boolean!
-  }
-
   type ReviewDetails {
     reviewerFirstName: String!
     reviewerLastName: String!


### PR DESCRIPTION
Removed duplicate ReviewedApplicantRecordDTO type definition.

There already exists one in `reviewPageType.ts` I believe.