### PR TITLE
[INTW26] Add new tables for migrations

### DIFF
--- a/backend/typescript/migrations/20260308004807-create-interview-groups-table.ts
+++ b/backend/typescript/migrations/20260308004807-create-interview-groups-table.ts
@@ -1,0 +1,27 @@
+import { DataType } from "sequelize-typescript";
+import { Migration } from "../umzug";
+
+const TABLE_NAME = "interview_groups";
+
+export const up: Migration = async ({ context: sequelize }) => {
+  await sequelize.getQueryInterface().createTable(TABLE_NAME, {
+    id: {
+      type: DataType.UUID,
+      defaultValue: DataType.UUIDV4,
+      primaryKey: true,
+    },
+    schedulingLink: {
+      type: DataType.STRING,
+      allowNull: false,
+    },
+    status: {
+      type: DataType.STRING,
+      allowNull: false,
+      defaultValue: "Availability Pending", // Default to "Availability Pending" when creating a new interview group
+    },
+  });
+};
+
+export const down: Migration = async ({ context: sequelize }) => {
+  await sequelize.getQueryInterface().dropTable(TABLE_NAME);
+};

--- a/backend/typescript/migrations/20260308004807-create-interview-groups-table.ts
+++ b/backend/typescript/migrations/20260308004807-create-interview-groups-table.ts
@@ -19,6 +19,16 @@ export const up: Migration = async ({ context: sequelize }) => {
       allowNull: false,
       defaultValue: "Availability Pending", // Default to "Availability Pending" when creating a new interview group
     },
+    createdAt: {
+      type: DataType.DATE,
+      allowNull: false,
+      defaultValue: DataType.NOW,
+    },
+    updatedAt: {
+      type: DataType.DATE,
+      allowNull: false,
+      defaultValue: DataType.NOW,
+    },
   });
 };
 

--- a/backend/typescript/migrations/20260308005440-migrate-interview-flow-to-interview-group.ts
+++ b/backend/typescript/migrations/20260308005440-migrate-interview-flow-to-interview-group.ts
@@ -1,16 +1,16 @@
 import { DataType } from "sequelize-typescript";
 import { Migration } from "../umzug";
 
-const INTERVIEW_GROUPS = "interview_groups";
+const INTERVIEW_GROUPS_TABLE = "interview_groups";
 const DELEGATIONS_TABLE = "interview_delegations";
 const INTERVIEW_APPLICANT_RECORDS_TABLE = "interviewed_applicant_records";
 
 export const up: Migration = async ({ context: sequelize }) => {
   await sequelize.getQueryInterface().addColumn(DELEGATIONS_TABLE, "groupId", {
     type: DataType.UUID,
-    allowNull: true,
+    allowNull: false,
     references: {
-      model: INTERVIEW_GROUPS,
+      model: INTERVIEW_GROUPS_TABLE,
       key: "id",
     },
   });

--- a/backend/typescript/migrations/20260308005440-migrate-interview-flow-to-interview-group.ts
+++ b/backend/typescript/migrations/20260308005440-migrate-interview-flow-to-interview-group.ts
@@ -1,0 +1,34 @@
+import { DataType } from "sequelize-typescript";
+import { Migration } from "../umzug";
+
+const INTERVIEW_GROUPS = "interview_groups";
+const DELEGATIONS_TABLE = "interview_delegations";
+const INTERVIEW_APPLICANT_RECORDS_TABLE = "interviewed_applicant_records";
+
+export const up: Migration = async ({ context: sequelize }) => {
+  await sequelize.getQueryInterface().addColumn(DELEGATIONS_TABLE, "groupId", {
+    type: DataType.UUID,
+    allowNull: true,
+    references: {
+      model: INTERVIEW_GROUPS,
+      key: "id",
+    },
+  });
+
+  await sequelize
+    .getQueryInterface()
+    .removeColumn(INTERVIEW_APPLICANT_RECORDS_TABLE, "schedulingLink");
+};
+
+export const down: Migration = async ({ context: sequelize }) => {
+  await sequelize
+    .getQueryInterface()
+    .addColumn(INTERVIEW_APPLICANT_RECORDS_TABLE, "schedulingLink", {
+      type: DataType.STRING,
+      allowNull: true,
+      defaultValue: null,
+    });
+  await sequelize
+    .getQueryInterface()
+    .removeColumn(DELEGATIONS_TABLE, "groupId");
+};

--- a/backend/typescript/models/interviewDelegation.model.ts
+++ b/backend/typescript/models/interviewDelegation.model.ts
@@ -23,19 +23,19 @@ export default class InterviewDelegation extends Model {
   @Column({ type: DataType.INTEGER, primaryKey: true })
   interviewerId!: number;
 
+  @ForeignKey(() => InterviewGroup)
+  @Column({
+    type: DataType.UUID,
+    allowNull: false,
+  })
+  groupId!: string;
+
   @Column({
     type: DataType.STRING,
     allowNull: true,
     defaultValue: null,
   })
   interviewHasConflict?: InterviewConflict;
-
-  @Column({
-    type: DataType.UUID,
-    allowNull: true,
-    defaultValue: null,
-  })
-  groupId?: string;
 
   @BelongsTo(() => InterviewedApplicantRecord, {
     foreignKey: "interviewedApplicantRecordId",

--- a/backend/typescript/models/interviewDelegation.model.ts
+++ b/backend/typescript/models/interviewDelegation.model.ts
@@ -1,5 +1,4 @@
 /* eslint import/no-cycle: 0 */
-
 import {
   BelongsTo,
   Column,
@@ -12,6 +11,7 @@ import { NonAttribute } from "sequelize";
 import { InterviewConflict } from "../types";
 import User from "./user.model";
 import InterviewedApplicantRecord from "./interviewedApplicantRecord.model";
+import InterviewGroup from "./interviewGroup.model";
 
 @Table({ tableName: "interview_delegations" })
 export default class InterviewDelegation extends Model {
@@ -30,6 +30,13 @@ export default class InterviewDelegation extends Model {
   })
   interviewHasConflict?: InterviewConflict;
 
+  @Column({
+    type: DataType.UUID,
+    allowNull: true,
+    defaultValue: null,
+  })
+  groupId?: string;
+
   @BelongsTo(() => InterviewedApplicantRecord, {
     foreignKey: "interviewedApplicantRecordId",
     targetKey: "id",
@@ -41,4 +48,10 @@ export default class InterviewDelegation extends Model {
     targetKey: "id",
   })
   interviewer?: NonAttribute<User>;
+
+  @BelongsTo(() => InterviewGroup, {
+    foreignKey: "groupId",
+    targetKey: "id",
+  })
+  interviewGroup?: NonAttribute<InterviewGroup>;
 }

--- a/backend/typescript/models/interviewGroup.model.ts
+++ b/backend/typescript/models/interviewGroup.model.ts
@@ -1,0 +1,23 @@
+/* eslint import/no-cycle: 0 */
+import { Column, DataType, HasMany, Model, Table } from "sequelize-typescript";
+import { InterviewGroupStatus, InterviewGroupStatusEnum } from "../types";
+import InterviewDelegation from "./interviewDelegation.model";
+
+@Table({ tableName: "interview_groups" })
+export default class InterviewGroup extends Model {
+  @Column({ type: DataType.UUIDV4, primaryKey: true })
+  id!: string;
+
+  @Column({ type: DataType.STRING, allowNull: true, defaultValue: null })
+  schedulingLink?: string;
+
+  @Column({
+    type: DataType.STRING,
+    allowNull: false,
+    defaultValue: InterviewGroupStatusEnum.AVAILABILITY_PENDING,
+  })
+  status!: InterviewGroupStatus;
+
+  @HasMany(() => InterviewDelegation, "groupId")
+  interviewDelegations?: InterviewDelegation[];
+}

--- a/backend/typescript/models/interviewGroup.model.ts
+++ b/backend/typescript/models/interviewGroup.model.ts
@@ -18,6 +18,20 @@ export default class InterviewGroup extends Model {
   })
   status!: InterviewGroupStatus;
 
+  @Column({
+    type: DataType.DATE,
+    allowNull: false,
+    defaultValue: DataType.NOW,
+  })
+  createdAt!: Date;
+
+  @Column({
+    type: DataType.DATE,
+    allowNull: false,
+    defaultValue: DataType.NOW,
+  })
+  updatedAt!: Date;
+
   @HasMany(() => InterviewDelegation, "groupId")
   interviewDelegations?: InterviewDelegation[];
 }

--- a/backend/typescript/models/interviewedApplicantRecord.model.ts
+++ b/backend/typescript/models/interviewedApplicantRecord.model.ts
@@ -5,7 +5,7 @@ import {
   Model,
   Table,
 } from "sequelize-typescript";
-import { Interview, InterviewStatus } from "../types";
+import { Interview, InterviewStatus, InterviewStatusEnum } from "../types";
 import ApplicantRecord from "./applicantRecord.model";
 import File from "./file.model";
 
@@ -41,7 +41,7 @@ export default class InterviewedApplicantRecord extends Model {
   @Column({
     type: DataType.STRING,
     allowNull: false,
-    defaultValue: "NeedsReview",
+    defaultValue: InterviewStatusEnum.NEEDS_REVIEW,
   })
   status!: InterviewStatus;
 
@@ -51,12 +51,6 @@ export default class InterviewedApplicantRecord extends Model {
     allowNull: true,
   })
   interviewNotesId?: string;
-
-  @Column({
-    type: DataType.STRING,
-    allowNull: true,
-  })
-  schedulingLink?: string;
 
   @Column({
     type: DataType.DATE,

--- a/backend/typescript/types.ts
+++ b/backend/typescript/types.ts
@@ -108,7 +108,14 @@ export type Interview = {
   comments?: string;
 };
 
-export type InterviewStatus = "NeedsReview" | "InProgress" | "Complete";
+export const InterviewStatusEnum = {
+  NEEDS_REVIEW: "Need Review",
+  IN_PROGRESS: "In Progress",
+  COMPLETE: "Complete",
+} as const;
+
+export type InterviewStatus =
+  (typeof InterviewStatusEnum)[keyof typeof InterviewStatusEnum];
 
 export type ApplicantRecordExtraInfo = {
   adminReview?: string;
@@ -194,14 +201,15 @@ export type ProductPositionTitle = (typeof ProductPositionTitles)[number];
 export type CommunityPositionTitle = (typeof CommunityPositionTitles)[number];
 export type PositionTitle = (typeof PositionTitles)[number];
 
-export enum ReviewStatusEnum {
-  TODO = "Todo",
-  IN_PROGRESS = "In Progress",
-  DONE = "Done",
-  CONFLICT = "Conflict",
-}
+export const ReviewStatusEnum = {
+  TODO: "Todo",
+  IN_PROGRESS: "In Progress",
+  DONE: "Done",
+  CONFLICT: "Conflict",
+} as const;
 
-export type ReviewStatus = `${ReviewStatusEnum}`;
+export type ReviewStatus =
+  (typeof ReviewStatusEnum)[keyof typeof ReviewStatusEnum];
 
 export type Review = {
   passionFSG?: number;
@@ -304,13 +312,24 @@ export type CreateFirebaseFileDTO = Omit<
   "id" | "createdAt" | "updatedAt"
 >;
 
-export const INTERVIEW_CONFLICT_OPTIONS = [
-  "APPLICANT_CONFLICT", // Conflict of interest with the applicant
-  "APPLICANT_NO_RESPONSE", // Applicant did not respond to the interview request
-  "PARTNER_NO_RESPONSE", // Partner did not respond to the interview request
-  "CANNOT_ATTEND", // Cannot make interview
-] as const;
-export type InterviewConflict = (typeof INTERVIEW_CONFLICT_OPTIONS)[number];
+export const InterviewConflictEnum = {
+  APPLICANT_CONFLICT: "APPLICANT_CONFLICT", // Conflict of interest with the applicant
+  APPLICANT_NO_RESPONSE: "APPLICANT_NO_RESPONSE", // Applicant did not respond to the interview request
+  PARTNER_NO_RESPONSE: "PARTNER_NO_RESPONSE", // Partner did not respond to the interview request
+  CANNOT_ATTEND: "CANNOT_ATTEND", // Cannot make interview
+};
+
+export type InterviewConflict =
+  (typeof InterviewConflictEnum)[keyof typeof InterviewConflictEnum];
+
+export const InterviewGroupStatusEnum = {
+  READY_TO_INTERVIEW: "Ready to Interview",
+  INVITES_SENT: "Invites Sent",
+  AVAILABILITY_PENDING: "Availability Pending",
+} as const;
+
+export type InterviewGroupStatus =
+  (typeof InterviewGroupStatusEnum)[keyof typeof InterviewGroupStatusEnum];
 
 export type InterviewDelegationDTO = {
   interviewedApplicantRecordId: string;

--- a/backend/typescript/types.ts
+++ b/backend/typescript/types.ts
@@ -256,7 +256,6 @@ export type InterviewedApplicantRecordDTO = {
   interviewJson?: Interview;
   status: InterviewStatus;
   interviewNotesId?: string;
-  schedulingLink?: string;
   interviewDate?: Date;
 };
 
@@ -318,7 +317,7 @@ export const InterviewConflictEnum = {
   APPLICANT_NO_RESPONSE: "APPLICANT_NO_RESPONSE", // Applicant did not respond to the interview request
   PARTNER_NO_RESPONSE: "PARTNER_NO_RESPONSE", // Partner did not respond to the interview request
   CANNOT_ATTEND: "CANNOT_ATTEND", // Cannot make interview
-};
+} as const;
 
 export type InterviewConflict = ValueOf<typeof InterviewConflictEnum>;
 
@@ -334,4 +333,5 @@ export type InterviewDelegationDTO = {
   interviewedApplicantRecordId: string;
   interviewerId: number;
   interviewHasConflict?: InterviewConflict;
+  interviewGroupId: string;
 };

--- a/backend/typescript/types.ts
+++ b/backend/typescript/types.ts
@@ -1,5 +1,9 @@
 export type Role = "User" | "Admin";
 
+type ValueOf<T> = T[keyof T];
+
+export type EnumType = ValueOf<typeof InterviewConflictEnum>;
+
 export enum StatusType {
   ACCEPTED = "accepted",
   APPLIED = "applied",
@@ -208,8 +212,7 @@ export const ReviewStatusEnum = {
   CONFLICT: "Conflict",
 } as const;
 
-export type ReviewStatus =
-  (typeof ReviewStatusEnum)[keyof typeof ReviewStatusEnum];
+export type ReviewStatus = ValueOf<typeof ReviewStatusEnum>;
 
 export type Review = {
   passionFSG?: number;
@@ -319,8 +322,7 @@ export const InterviewConflictEnum = {
   CANNOT_ATTEND: "CANNOT_ATTEND", // Cannot make interview
 };
 
-export type InterviewConflict =
-  (typeof InterviewConflictEnum)[keyof typeof InterviewConflictEnum];
+export type InterviewConflict = ValueOf<typeof InterviewConflictEnum>;
 
 export const InterviewGroupStatusEnum = {
   READY_TO_INTERVIEW: "Ready to Interview",
@@ -328,8 +330,7 @@ export const InterviewGroupStatusEnum = {
   AVAILABILITY_PENDING: "Availability Pending",
 } as const;
 
-export type InterviewGroupStatus =
-  (typeof InterviewGroupStatusEnum)[keyof typeof InterviewGroupStatusEnum];
+export type InterviewGroupStatus = ValueOf<typeof InterviewGroupStatusEnum>;
 
 export type InterviewDelegationDTO = {
   interviewedApplicantRecordId: string;

--- a/backend/typescript/types.ts
+++ b/backend/typescript/types.ts
@@ -2,8 +2,6 @@ export type Role = "User" | "Admin";
 
 type ValueOf<T> = T[keyof T];
 
-export type EnumType = ValueOf<typeof InterviewConflictEnum>;
-
 export enum StatusType {
   ACCEPTED = "accepted",
   APPLIED = "applied",


### PR DESCRIPTION
## Notion ticket link
<!-- Please replace with your ticket's URL -->
[Build InterviewGroup Table](https://www.notion.so/uwblueprintexecs/Build-InterviewGroup-Table-31a10f3fb1dc807a8127cd231863b661?v=6b710f3fb1dc83d7b43d08147fd183be&source=copy_link)

[Modify Interviewer Delegations and Interviewed Applicant Records tables](https://www.notion.so/uwblueprintexecs/Modify-Interviewer-Delegations-and-Interviewed-Applicant-Records-tables-31a10f3fb1dc809c9b14fe19be4d1784?v=6b710f3fb1dc83d7b43d08147fd183be&source=copy_link)


<!-- Give a quick summary of the implementation details, provide design justifications if necessary -->
## Implementation description
* Added InterviewGroup Table - this table allows for multiple `interviewedApplicantRecords` to share the same scheduling link, this is added according to the [Interview Group model described in the TDD](https://www.notion.so/uwblueprintexecs/Technical-Design-Document-20b10f3fb1dc80f5bfe0ccb32821c325?source=copy_link#31910f3fb1dc8079a578f785a966f211)
* Added groupId column to `interviewDelegations` - each delegation must belongs to an `interviewGroup`
* Removed schedulingLink column from `interviewedApplicantRecords` since multiple interviewedApplicantRecords can share the same schedulingLink now
* Improved some of the typings such that constant string values are stored in accessible enums (mainly used for status)


<!-- What should the reviewer do to verify your changes? Describe expected results and include screenshots when appropriate -->
## Steps to test
1. Run the backend docker container and run `docker exec recruitment_tools_backend node migrate up` to run the migrations. Ensure the following:
  - `interviewGroup` table is correctly added to the database.
  - `interviewedDelegations` table has a foreign key to the `interviewGroup` table. 
  - `intervewedApplicantRecords` table's schedulingLink column is removed
3. Run `docker exec recruitment_tools_backend node migrate down` to unapply migrations. Ensure the `interviewGroup` table is removed and column changes to `interviewedApplicantRecords` and `interviewedDelegations` are applied.


<!-- Draw attention to the substantial parts of your PR or anything you'd like a second opinion on -->
## What should reviewers focus on?
* All column models in the TDD are correctly implemented with the correct type, default values, and constraints.
* 


## Checklist
- [x] My PR name is descriptive and in imperative tense
- [x] My commit messages are descriptive and in imperative tense. My commits are atomic and trivial commits are squashed or fixup'd into non-trivial commits
- [x] I have run the appropriate linter(s)
- [x] I have requested a review from the PL, as well as other devs who have background knowledge on this PR or who will be building on top of this PR
