### PR TITLE
[INTW26] Build Interview Delegation Algorithm + Interview Group CRUD Endpoints

### DIFF
--- a/backend/typescript/graphql/index.ts
+++ b/backend/typescript/graphql/index.ts
@@ -134,6 +134,8 @@ const graphQLMiddlewares = {
     bulkCreateInterviewDelegations: authorizedByAllRoles(),
     bulkDeleteInterviewDelegations: authorizedByAllRoles(),
     createInterviewGroup: authorizedByAllRoles(),
+    bulkCreateInterviewGroups: authorizedByAllRoles(),
+    bulkDeleteInterviewGroupsByIds: authorizedByAllRoles(),
     deleteInterviewGroupById: authorizedByAllRoles(),
     updateInterviewGroup: authorizedByAllRoles(),
   },

--- a/backend/typescript/graphql/index.ts
+++ b/backend/typescript/graphql/index.ts
@@ -33,6 +33,8 @@ import interviewPageResolvers from "./resolvers/interviewPageResolvers";
 import interviewPageType from "./types/interviewPageTypes";
 import interviewGroupTypes from "./types/interviewGroupTypes";
 import interviewGroupResolvers from "./resolvers/interviewGroupResolvers";
+import interviewDashboardTypes from "./types/interviewDashboardTypes";
+import interviewDashboardResolvers from "./resolvers/interviewDashboardResolvers";
 
 const query = gql`
   type Query {
@@ -60,6 +62,7 @@ const executableSchema = makeExecutableSchema({
     applicantRecordType,
     reviewPageType,
     interviewDelegationsTypes,
+    interviewDashboardTypes,
     reviewedApplicantRecordTypes,
     interviewedApplicantRecordsTypes,
     interviewPageType,
@@ -76,6 +79,7 @@ const executableSchema = makeExecutableSchema({
     applicantRecordResolvers,
     reviewPageResolvers,
     interviewDelegationsResolvers,
+    interviewDashboardResolvers,
     reviewedApplicantRecordResolvers,
     interviewedApplicantRecordsResolvers,
     interviewPageResolvers,
@@ -133,6 +137,7 @@ const graphQLMiddlewares = {
     deleteInterviewDelegation: authorizedByAllRoles(),
     bulkCreateInterviewDelegations: authorizedByAllRoles(),
     bulkDeleteInterviewDelegations: authorizedByAllRoles(),
+    delegateInterviewers: authorizedByAllRoles(),
     createInterviewGroup: authorizedByAllRoles(),
     bulkCreateInterviewGroups: authorizedByAllRoles(),
     bulkDeleteInterviewGroupsByIds: authorizedByAllRoles(),

--- a/backend/typescript/graphql/resolvers/interviewDashboardResolvers.ts
+++ b/backend/typescript/graphql/resolvers/interviewDashboardResolvers.ts
@@ -1,0 +1,26 @@
+import InterviewDashboardService from "../../services/implementations/interviewDashboardService";
+import IInterviewDashboardService from "../../services/interfaces/IInterviewDasboardService";
+import { InterviewDelegationDTO } from "../../types";
+import { getErrorMessage } from "../../utilities/errorUtils";
+
+const interviewDashboardService: IInterviewDashboardService =
+  new InterviewDashboardService();
+
+const interviewDashboardResolvers = {
+  Mutation: {
+    delegateInterviewers: async (
+      _parent: undefined,
+      args: { positions: string[] },
+    ): Promise<InterviewDelegationDTO[]> => {
+      try {
+        return await interviewDashboardService.delegateInterviewers(
+          args.positions,
+        );
+      } catch (error) {
+        throw new Error(getErrorMessage(error));
+      }
+    },
+  },
+};
+
+export default interviewDashboardResolvers;

--- a/backend/typescript/graphql/resolvers/interviewGroupResolvers.ts
+++ b/backend/typescript/graphql/resolvers/interviewGroupResolvers.ts
@@ -67,6 +67,32 @@ const interviewGroupResolvers = {
         throw new Error(getErrorMessage(error));
       }
     },
+
+    bulkCreateInterviewGroups: async (
+      _parent: undefined,
+      args: { interviewGroups: CreateInterviewGroupDTO[] },
+    ): Promise<InterviewGroupDTO[]> => {
+      try {
+        return await interviewGroupService.bulkCreateInterviewGroups(
+          args.interviewGroups,
+        );
+      } catch (error) {
+        throw new Error(getErrorMessage(error));
+      }
+    },
+
+    bulkDeleteInterviewGroupsByIds: async (
+      _parent: undefined,
+      args: { interviewGroupIds: string[] },
+    ): Promise<InterviewGroupDTO[]> => {
+      try {
+        return await interviewGroupService.bulkDeleteInterviewGroupsByIds(
+          args.interviewGroupIds,
+        );
+      } catch (error) {
+        throw new Error(getErrorMessage(error));
+      }
+    },
   },
 };
 

--- a/backend/typescript/graphql/types/interviewDashboardTypes.ts
+++ b/backend/typescript/graphql/types/interviewDashboardTypes.ts
@@ -1,0 +1,9 @@
+import { gql } from "apollo-server-express";
+
+const interviewDashboardTypes = gql`
+  extend type Mutation {
+    delegateInterviewers(positions: [String!]!): [InterviewDelegation!]!
+  }
+`;
+
+export default interviewDashboardTypes;

--- a/backend/typescript/graphql/types/interviewGroupTypes.ts
+++ b/backend/typescript/graphql/types/interviewGroupTypes.ts
@@ -32,6 +32,14 @@ const interviewGroupTypes = gql`
     ): InterviewGroupDTO!
 
     deleteInterviewGroupById(id: ID!): InterviewGroupDTO!
+
+    bulkCreateInterviewGroups(
+      interviewGroups: [CreateInterviewGroupDTO]!
+    ): [InterviewGroupDTO]!
+
+    bulkDeleteInterviewGroupsByIds(
+      interviewGroupIds: [ID]!
+    ): [InterviewGroupDTO]!
   }
 `;
 

--- a/backend/typescript/services/implementations/interviewDashboardService.ts
+++ b/backend/typescript/services/implementations/interviewDashboardService.ts
@@ -34,7 +34,9 @@ function interviewerTeamKey(a: InterviewerAssignment): string {
     (x): x is number => x !== undefined,
   );
   if (ids.length === 0) {
-    throw new Error("No interviewers assigned to this interviewed applicant record.");
+    throw new Error(
+      "No interviewers assigned to this interviewed applicant record.",
+    );
   }
   if (ids.length === 1) {
     return `solo:${ids[0]}`;
@@ -57,7 +59,6 @@ class InterviewDashboardServices implements IInterviewDashboardService {
     positions: string[],
   ): Promise<InterviewDelegationDTO[]> {
     try {
-
       // Get all users by position.
       const groups = (
         await User.findAll({
@@ -100,7 +101,6 @@ class InterviewDashboardServices implements IInterviewDashboardService {
           ],
         });
 
-      
       // Round robin the interviewers for each interviewed applicant record.
       const assignments: InterviewerAssignment[] = [];
 
@@ -157,8 +157,8 @@ class InterviewDashboardServices implements IInterviewDashboardService {
       );
 
       // Create the interview delegations.
-      const delegations: CreateInterviewDelegationDTO[] =
-        assignments.flatMap((a) => {
+      const delegations: CreateInterviewDelegationDTO[] = assignments.flatMap(
+        (a) => {
           const groupId = groupIdByTeamKey[interviewerTeamKey(a)];
           const row: CreateInterviewDelegationDTO[] = [];
           if (a.interviewer1 !== undefined) {
@@ -176,7 +176,8 @@ class InterviewDashboardServices implements IInterviewDashboardService {
             });
           }
           return row;
-        });
+        },
+      );
 
       return await interviewDelegationsService.bulkCreateInterviewDelegations(
         delegations,

--- a/backend/typescript/services/implementations/interviewDashboardService.ts
+++ b/backend/typescript/services/implementations/interviewDashboardService.ts
@@ -1,0 +1,193 @@
+import { Op } from "sequelize";
+import User from "../../models/user.model";
+import InterviewedApplicantRecord from "../../models/interviewedApplicantRecord.model";
+import {
+  CreateInterviewDelegationDTO,
+  InterviewDelegationDTO,
+  InterviewGroupStatusEnum,
+} from "../../types";
+import { getErrorMessage } from "../../utilities/errorUtils";
+import logger from "../../utilities/logger";
+import IInterviewDashboardService from "../interfaces/IInterviewDasboardService";
+import InterviewDelegationsService from "./interviewDelegationsService";
+import IInterviewDelegationsService from "../interfaces/IInterviewDelegationsService";
+import InterviewGroupService from "./interviewGroupService";
+import IInterviewGroupService from "../interfaces/IInterviewGroupService";
+
+const Logger = logger(__filename);
+
+const interviewDelegationsService: IInterviewDelegationsService =
+  new InterviewDelegationsService();
+
+const interviewGroupService: IInterviewGroupService =
+  new InterviewGroupService();
+
+type InterviewerAssignment = {
+  interviewedApplicantRecordId: string;
+  interviewer1?: number;
+  interviewer2?: number;
+};
+
+/** Assign a unique key to each interviewer group - this should be indifferent to ordering of the interviewers. */
+function interviewerTeamKey(a: InterviewerAssignment): string {
+  const ids = [a.interviewer1, a.interviewer2].filter(
+    (x): x is number => x !== undefined,
+  );
+  if (ids.length === 0) {
+    throw new Error("No interviewers assigned to this interviewed applicant record.");
+  }
+  if (ids.length === 1) {
+    return `solo:${ids[0]}`;
+  }
+
+  // Order the interviewers so that the smaller ID is first.
+  const [x, y] = ids[0] <= ids[1] ? [ids[0], ids[1]] : [ids[1], ids[0]];
+  return `pair:${x}|${y}`;
+}
+
+class InterviewDashboardServices implements IInterviewDashboardService {
+  /* eslint-disable class-methods-use-this */
+  /**
+   * Assignment logic matches {@link ReviewDashboardService.delegateReviewers}:
+   * per position, circular user list with `undefined` sentinel when count is odd;
+   * each record consumes two consecutive FSM slots for its two interviewers.
+   * Interview groups are deduped by interviewer team so identical pairs share `groupId`.
+   */
+  async delegateInterviewers(
+    positions: string[],
+  ): Promise<InterviewDelegationDTO[]> {
+    try {
+
+      // Get all users by position.
+      const groups = (
+        await User.findAll({
+          attributes: { exclude: ["createdAt", "updatedAt"] },
+          where: { position: { [Op.in]: positions } },
+        })
+      ).reduce((map, user) => {
+        // eslint-disable-next-line @typescript-eslint/no-non-null-assertion
+        const pos = user.position!;
+        const arr = map.get(pos) ?? [];
+        arr.push(user.id);
+        map.set(pos, arr);
+        return map;
+      }, new Map<string, number[]>());
+
+      // Build the FSM.
+      const FSM = new Map<string, [number, (number | undefined)[]]>(
+        positions.map((title) => [title, [0, groups.get(title) ?? []]]),
+      );
+
+      Array.from(FSM.entries()).forEach(([title, [, userIds]]) => {
+        if (userIds.length === 0) {
+          throw new Error(`Invalid amount of users with position ${title}.`);
+        }
+        if (userIds.length % 2 !== 0) {
+          userIds.push(undefined);
+        }
+      });
+
+      // Get all interviewer assignments for the given positions.
+      const interviewedApplicantRecords =
+        await InterviewedApplicantRecord.findAll({
+          attributes: ["id"],
+          include: [
+            {
+              association: "applicantRecord",
+              attributes: ["position"],
+              where: { position: { [Op.in]: positions } },
+            },
+          ],
+        });
+
+      
+      // Round robin the interviewers for each interviewed applicant record.
+      const assignments: InterviewerAssignment[] = [];
+
+      interviewedApplicantRecords.forEach((record) => {
+        const position = record.applicantRecord?.position;
+        if (!position || !FSM.has(position)) {
+          return;
+        }
+
+        /* eslint-disable @typescript-eslint/no-non-null-assertion */
+        const [count, userIds] = FSM.get(position)!;
+        let newCount = count;
+        const assigned1 = FSM.get(position)![1][newCount];
+        newCount++;
+        newCount %= FSM.get(position)![1].length;
+        const assigned2 = FSM.get(position)![1][newCount];
+        newCount++;
+        newCount %= FSM.get(position)![1].length;
+        FSM.set(position, [newCount, userIds]);
+
+        if (assigned1 === undefined && assigned2 === undefined) {
+          return;
+        }
+
+        assignments.push({
+          interviewedApplicantRecordId: record.id,
+          interviewer1: assigned1,
+          interviewer2: assigned2,
+        });
+      });
+
+      if (assignments.length === 0) {
+        return [];
+      }
+
+      // Dedupe the team keys to avoid creating duplicate interview groups.
+      const dedupedTeamKeys = [...new Set(assignments.map(interviewerTeamKey))];
+
+      // Create the interview groups.
+      const createdGroups =
+        await interviewGroupService.bulkCreateInterviewGroups(
+          dedupedTeamKeys.map(() => ({
+            status: InterviewGroupStatusEnum.AVAILABILITY_PENDING,
+          })),
+        );
+
+      // Map delegated assignments to a singular group ID.
+      const groupIdByTeamKey = dedupedTeamKeys.reduce<Record<string, string>>(
+        (acc, teamKey, i) => {
+          acc[teamKey] = createdGroups[i].id;
+          return acc;
+        },
+        {},
+      );
+
+      // Create the interview delegations.
+      const delegations: CreateInterviewDelegationDTO[] =
+        assignments.flatMap((a) => {
+          const groupId = groupIdByTeamKey[interviewerTeamKey(a)];
+          const row: CreateInterviewDelegationDTO[] = [];
+          if (a.interviewer1 !== undefined) {
+            row.push({
+              interviewedApplicantRecordId: a.interviewedApplicantRecordId,
+              interviewerId: a.interviewer1,
+              groupId,
+            });
+          }
+          if (a.interviewer2 !== undefined) {
+            row.push({
+              interviewedApplicantRecordId: a.interviewedApplicantRecordId,
+              interviewerId: a.interviewer2,
+              groupId,
+            });
+          }
+          return row;
+        });
+
+      return await interviewDelegationsService.bulkCreateInterviewDelegations(
+        delegations,
+      );
+    } catch (error: unknown) {
+      Logger.error(
+        `Failed to delegate interviewers. Reason = ${getErrorMessage(error)}`,
+      );
+      throw error;
+    }
+  }
+}
+
+export default InterviewDashboardServices;

--- a/backend/typescript/services/implementations/interviewGroupService.ts
+++ b/backend/typescript/services/implementations/interviewGroupService.ts
@@ -1,3 +1,5 @@
+import { sequelize } from "../../models";
+import InterviewDelegation from "../../models/interviewDelegation.model";
 import InterviewGroup from "../../models/interviewGroup.model";
 import {
   CreateInterviewGroupDTO,
@@ -60,13 +62,14 @@ class InterviewGroupService implements IInterviewGroupService {
     interviewGroup: UpdateInterviewGroupDTO,
   ): Promise<InterviewGroupDTO> {
     try {
+      const { schedulingLink, status } = interviewGroup;
       const existing = await InterviewGroup.findByPk(id);
       if (!existing) {
         throw new Error(`No interview group found for id: ${id}`);
       }
 
-      await existing.update(interviewGroup);
-      return toInterviewGroupDTO(existing);
+      const updatedGroup = await existing.update({ schedulingLink, status });
+      return toInterviewGroupDTO(updatedGroup);
     } catch (error: unknown) {
       Logger.error(
         `Failed to update interview group. Reason = ${getErrorMessage(error)}`,
@@ -87,6 +90,70 @@ class InterviewGroupService implements IInterviewGroupService {
       Logger.error(
         `Failed to delete interview group. Reason = ${getErrorMessage(error)}`,
       );
+      throw error;
+    }
+  }
+
+  async bulkCreateInterviewGroups(
+    groups: CreateInterviewGroupDTO[],
+  ): Promise<InterviewGroupDTO[]> {
+    const t = await sequelize.transaction();
+    try {
+      const createdGroups = await InterviewGroup.bulkCreate(groups, {
+        transaction: t,
+      });
+
+      await t.commit();
+      return createdGroups.map((group) => toInterviewGroupDTO(group));
+    } catch (error: unknown) {
+      Logger.error(
+        `Failed to bulk create interview groups. Reason = ${getErrorMessage(
+          error,
+        )}`,
+      );
+      await t.rollback();
+      throw error;
+    }
+  }
+
+  async bulkDeleteInterviewGroupsByIds(
+    ids: string[],
+  ): Promise<InterviewGroupDTO[]> {
+    const t = await sequelize.transaction();
+    try {
+      if (ids.length === 0) {
+        return [];
+      }
+      const foundGroups = await InterviewGroup.findAll({
+        where: { id: ids },
+        transaction: t,
+      });
+      if (foundGroups.length !== ids.length) {
+        throw new Error(
+          "Not all interview groups were found, bulk delete failed",
+        );
+      }
+
+      // Delete all interview delegations for the found groups
+      await InterviewDelegation.destroy({
+        where: { groupId: foundGroups.map((group) => group.id) },
+        transaction: t,
+      });
+      // Delete all interview groups
+      await InterviewGroup.destroy({
+        where: { id: foundGroups.map((group) => group.id) },
+        transaction: t,
+      });
+
+      await t.commit();
+      return foundGroups.map((group) => toInterviewGroupDTO(group));
+    } catch (error: unknown) {
+      Logger.error(
+        `Failed to bulk delete interview groups. Reason = ${getErrorMessage(
+          error,
+        )}`,
+      );
+      await t.rollback();
       throw error;
     }
   }

--- a/backend/typescript/services/interfaces/IInterviewDasboardService.ts
+++ b/backend/typescript/services/interfaces/IInterviewDasboardService.ts
@@ -1,6 +1,6 @@
 import { InterviewDelegationDTO } from "../../types";
 
-interface IInterviewDashboardService{
+interface IInterviewDashboardService {
   /**
    * Delegates interviewers to interview applicants.
    */

--- a/backend/typescript/services/interfaces/IInterviewDasboardService.ts
+++ b/backend/typescript/services/interfaces/IInterviewDasboardService.ts
@@ -1,0 +1,10 @@
+import { InterviewDelegationDTO } from "../../types";
+
+interface IInterviewDashboardService{
+  /**
+   * Delegates interviewers to interview applicants.
+   */
+  delegateInterviewers(positions: string[]): Promise<InterviewDelegationDTO[]>;
+}
+
+export default IInterviewDashboardService;

--- a/backend/typescript/services/interfaces/IInterviewGroupService.ts
+++ b/backend/typescript/services/interfaces/IInterviewGroupService.ts
@@ -13,8 +13,7 @@ interface IInterviewGroupService {
 
   /**
    * Creates a new interview group.
-   * @param status initial status
-   * @param schedulingLink scheduling link, or undefined if not yet set
+   * @param interviewGroup initial interview group
    */
   createInterviewGroup(
     interviewGroup: CreateInterviewGroupDTO,
@@ -23,8 +22,7 @@ interface IInterviewGroupService {
   /**
    * Updates an existing interview group.
    * @param id PK of the interview group to update
-   * @param status updated status
-   * @param schedulingLink updated scheduling link, or undefined to clear it
+   * @param interviewGroup updated interview group
    */
   updateInterviewGroup(
     id: string,
@@ -36,6 +34,22 @@ interface IInterviewGroupService {
    * @param id PK of the interview group to delete
    */
   deleteInterviewGroupById(id: string): Promise<InterviewGroupDTO>;
+
+  /**
+   * Bulk creates interview groups.
+   * @param interviewGroups list of interview groups to create
+   */
+  bulkCreateInterviewGroups(
+    interviewGroups: CreateInterviewGroupDTO[],
+  ): Promise<InterviewGroupDTO[]>;
+
+  /**
+   * Bulk deletes interview groups by ids.
+   * @param interviewGroupIds list of interview group ids to delete
+   */
+  bulkDeleteInterviewGroupsByIds(
+    interviewGroupIds: string[],
+  ): Promise<InterviewGroupDTO[]>;
 }
 
 export default IInterviewGroupService;


### PR DESCRIPTION
## Notion ticket link
<!-- Please replace with your ticket's URL -->
[Build Interview Delegation Algorithm](https://www.notion.so/uwblueprintexecs/Build-Interview-Delegation-Algorithm-31910f3fb1dc80888515e4f4230ac674?source=copy_link)


<!-- Give a quick summary of the implementation details, provide design justifications if necessary -->
## Implementation description
* Add service functions, resolvers, and graphql types to implement crud endpoints for interview groups
* Add service functions, resolvers, and graphql types to implement a delegate interviewers function


<!-- What should the reviewer do to verify your changes? Describe expected results and include screenshots when appropriate -->
## Steps to test

### Interview Group CRUD
1. Start the backend with `docker compose up`
2. Run the following graphql queries and ensure they run with no errors, as well as the `interview_groups` table content makes sense after each query
```graphql
mutation CreateInterviewGroup {
    createInterviewGroup(status: "Availability Pending", schedulingLink: "link") {
        id
        schedulingLink
        status
    }
}

# make sure to note down the id it returns for the next 3 queries
```
```graphql
mutation UpdateInterviewGroup {
    updateInterviewGroup(
        id: "<INTERVIEW_GROUP_ID>"
        status: "Ready to Interview"
        schedulingLink: "another_link"
    ) {
        id
        schedulingLink
        status
    }
}
```
```graphql
query GetInterviewGroup {
    getInterviewGroup(id: "<INTERVIEW_GROUP_ID>") {
        id
        schedulingLink
        status
    }
}
```
```graphql
mutation DeleteInterviewGroup {
    deleteInterviewGroup(id: "<INTERVIEW_GROUP_ID>") {
        id
        schedulingLink
        status
    }
}
```
```graphql
mutation BulkCreateInterviewGroups($groups: [BulkCreateInterviewGroupInput!]!) {
    bulkCreateInterviewGroups(groups: $groups) {
        id
        schedulingLink
        status
    }
}

# use the query variables below
 {
    "groups": [
      {
        "status": "Availability Pending"
      },
      {
        "status": "Invites Sent",
        "schedulingLink": "https://calendly.com/interviewer-a"
      },
      {
        "status": "Ready to Interview",
        "schedulingLink": "https://calendly.com/interviewer-b"
      }
    ]
  }

# note the group ids created here for the next query
```
```graphql
mutation BulkDeleteInterviewGroups ($ids:[String!]!) {
    bulkDeleteInterviewGroups(ids: $ids) {
        id
        schedulingLink
        status
    }
}

# use the query variables below
{
  "ids": [
    "<INTERVIEW_GROUP_ID_1>",
    "<INTERVIEW_GROUP_ID_2>",
    "<INTERVIEW_GROUP_ID_3>"
  ]
}
```

### Delegation Algorithm
1. Start the backend with `docker compose up`
4. Run the following sql queries separately and in order to create copies of each existing seeded applicant record
```sql
CREATE EXTENSION IF NOT EXISTS pgcrypto;
```
```sql
INSERT INTO public.interviewed_applicant_records (id, "applicantRecordId", status, "createdAt", "updatedAt")
SELECT
	gen_random_uuid(),
	id,
	'NeedsReview',
	NOW(),
	NOW()
FROM public.applicant_records
ON CONFLICT ("applicantRecordId") DO NOTHING;
```
5. Run the following sql query to create a bunch of dummy users with position "Developer"
```sql
INSERT INTO users (first_name, last_name, email, auth_id, role, position, "isActive")
VALUES
  ('Test', 'User1',  'testuser1@test.com',  'test_auth_1',  'User', 'Developer', true),
  ('Test', 'User2',  'testuser2@test.com',  'test_auth_2',  'User', 'Developer', true),
  ('Test', 'User3',  'testuser3@test.com',  'test_auth_3',  'User', 'Developer', true),
  ('Test', 'User4',  'testuser4@test.com',  'test_auth_4',  'User', 'Developer', true),
  ('Test', 'User5',  'testuser5@test.com',  'test_auth_5',  'User', 'Developer', true),
  ('Test', 'User6',  'testuser6@test.com',  'test_auth_6',  'User', 'Developer', true),
  ('Test', 'User7',  'testuser7@test.com',  'test_auth_7',  'User', 'Developer', true),
  ('Test', 'User8',  'testuser8@test.com',  'test_auth_8',  'User', 'Developer', true),
  ('Test', 'User9',  'testuser9@test.com',  'test_auth_9',  'User', 'Developer', true),
  ('Test', 'User10', 'testuser10@test.com', 'test_auth_10', 'User', 'Developer', true),
  ('Test', 'User11', 'testuser11@test.com', 'test_auth_11', 'User', 'Developer', true);
```
6. Run the following mutator
```graphql
mutation DelegateInterviewers {
    delegateInterviewers(positions: ["Developer", "VP Engineering"]) {
        interviewedApplicantRecordId
        interviewerId
        interviewHasConflict
        groupId
    }
}
```
7. icl i asked claude to give some queries to test this

```sql
-- 1. Each applicant still gets exactly 1 or 2 interviewers (unchanged):
SELECT "interviewedApplicantRecordId", COUNT(*) AS interviewer_count
FROM public.interview_delegations
GROUP BY "interviewedApplicantRecordId"
HAVING COUNT(*) NOT IN (1, 2);
-- Should return no rows

-- 2. Both interviewers for the same applicant share the same group (unchanged):
SELECT "interviewedApplicantRecordId", COUNT(DISTINCT "groupId") AS group_count
FROM public.interview_delegations
GROUP BY "interviewedApplicantRecordId"
HAVING COUNT(DISTINCT "groupId") > 1;
-- Should return no rows

-- 3. No interviewer is ever solo unless the position truly has only 1 interviewer
-- (new — replaces the old "one group per interviewer" check):
SELECT d."interviewerId"
FROM public.interview_delegations d
WHERE d."interviewedApplicantRecordId" IN (
  SELECT "interviewedApplicantRecordId"
  FROM public.interview_delegations
  GROUP BY "interviewedApplicantRecordId"
  HAVING COUNT(*) = 1
)
GROUP BY d."interviewerId";
-- Should only return interviewers from positions with exactly 1 interviewer total.

-- 4. Interviewers spanning multiple groups (proves wrap-around actually occurred for
-- odd counts):
SELECT "interviewerId", COUNT(DISTINCT "groupId") AS group_count
FROM public.interview_delegations
GROUP BY "interviewerId"
HAVING COUNT(DISTINCT "groupId") > 1;
-- For even-count positions → no rows. For odd-count positions → some interviewers
-- should appear here.

-- 5. Load distribution across groups (unchanged):
SELECT "groupId", COUNT(DISTINCT "interviewedApplicantRecordId") AS applicant_count
FROM public.interview_delegations
GROUP BY "groupId"
ORDER BY "groupId";
-- Note that since we delegated for two roles, there's gonna be two pools of count ranges.

-- 6. At most 2 interviewers are assigned per group
SELECT
  "groupId",
  COUNT(DISTINCT "interviewerId") AS interviewer_count
FROM interview_delegations
GROUP BY "groupId"
HAVING COUNT(DISTINCT "interviewerId") > 2;
-- Should return no rows

-- 7. Even distribution among interviewers
WITH interviewer_loads AS (
  SELECT
    d."interviewerId",
    u.position,
    COUNT(DISTINCT d."interviewedApplicantRecordId") AS applicant_count
  FROM public.interview_delegations d
  JOIN public.users u ON u.id = d."interviewerId"
  GROUP BY d."interviewerId", u.position
)
SELECT
  position,
  "interviewerId",
  applicant_count,
  MAX(applicant_count) OVER (PARTITION BY position) - MIN(applicant_count) OVER (PARTITION BY position)
 AS load_spread
FROM interviewer_loads
ORDER BY position, applicant_count DESC;
```

<!-- Draw attention to the substantial parts of your PR or anything you'd like a second opinion on -->
## What should reviewers focus on?

### Interview Group CRUD
* Create and Update accept null `schedulingLink`
* If update does not provide a `schedulingLink`, the row's `schedulingLink` value should not change


## Checklist
- [x] My PR name is descriptive and in imperative tense
- [x] My commit messages are descriptive and in imperative tense. My commits are atomic and trivial commits are squashed or fixup'd into non-trivial commits
- [x] I have run the appropriate linter(s)
- [x] I have requested a review from the PL, as well as other devs who have background knowledge on this PR or who will be building on top of this PR
