### PR TITLE
[INTW26] File upload POC

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -10,6 +10,8 @@
 **/*.cache
 **/*.egg-info
 backend/typescript/serviceAccount.json
+backend/typescript/uploads/*
+!backend/typescript/uploads/.gitkeep
 package-lock.json
 .gitignore
 package.json

--- a/backend/typescript/graphql/index.ts
+++ b/backend/typescript/graphql/index.ts
@@ -25,6 +25,8 @@ import applicantRecordResolvers from "./resolvers/applicantRecordResolvers";
 import applicantRecordType from "./types/applicantRecordType";
 import reviewPageType from "./types/reviewPageType";
 import reviewPageResolvers from "./resolvers/reviewPageResolvers";
+import firebaseFileType from "./types/firebaseFileType";
+import firebaseFileResolvers from "./resolvers/firebaseFileResolvers";
 
 const query = gql`
   type Query {
@@ -52,6 +54,7 @@ const executableSchema = makeExecutableSchema({
     applicantRecordType,
     reviewPageType,
     reviewedApplicantRecordTypes,
+    firebaseFileType,
   ],
   resolvers: merge(
     authResolvers,
@@ -64,6 +67,7 @@ const executableSchema = makeExecutableSchema({
     applicantRecordResolvers,
     reviewPageResolvers,
     reviewedApplicantRecordResolvers,
+    firebaseFileResolvers,
   ),
 });
 
@@ -106,6 +110,7 @@ const graphQLMiddlewares = {
     createAdminComment: authorizedByAdmin(),
     updateAdminComment: authorizedByAdmin(),
     deleteAdminCommentById: authorizedByAdmin(),
+    createFirebaseFile: authorizedByAllRoles(),
   },
 };
 

--- a/backend/typescript/graphql/resolvers/firebaseFileResolvers.ts
+++ b/backend/typescript/graphql/resolvers/firebaseFileResolvers.ts
@@ -1,0 +1,74 @@
+import fs from "fs";
+import { FileUpload } from "graphql-upload";
+/* eslint-disable-next-line import/no-extraneous-dependencies */
+import { ReadStream } from "fs-capacitor";
+import { v4 as uuidv4 } from "uuid";
+import FirebaseFileService from "../../services/implementations/firebaseFileService";
+import FileStorageService from "../../services/implementations/fileStorageService";
+import IFirebaseFileService from "../../services/interfaces/firebaseFileService";
+import { FirebaseFileDTO } from "../../types";
+import {
+  validateFileType,
+  getFileTypeValidationError,
+} from "../../middlewares/validators/util";
+
+const defaultBucket = process.env.FIREBASE_STORAGE_DEFAULT_BUCKET || "";
+const fileStorageService = new FileStorageService(defaultBucket);
+const firebaseFileService: IFirebaseFileService = new FirebaseFileService(
+  fileStorageService,
+);
+
+const writeFile = (readStream: ReadStream, filePath: string): Promise<void> => {
+  return new Promise((resolve, reject) => {
+    const out = fs.createWriteStream(filePath);
+    readStream.pipe(out);
+    out.on("finish", () => {
+      resolve();
+    });
+    out.on("error", (err) => reject(err));
+  });
+};
+
+const firebaseFileResolvers = {
+  Mutation: {
+    createFirebaseFile: async (
+      _parent: undefined,
+      {
+        file,
+        uploadedUserId,
+      }: { file: Promise<FileUpload>; uploadedUserId: number },
+    ): Promise<FirebaseFileDTO> => {
+      const { createReadStream, mimetype, filename } = await file;
+
+      if (!validateFileType(mimetype)) {
+        throw new Error(getFileTypeValidationError(mimetype));
+      }
+
+      const uploadDir = "uploads";
+      const tempFilePath = `${uploadDir}/${filename}`;
+
+      await writeFile(createReadStream(), tempFilePath);
+
+      const sizeBytes = BigInt(fs.statSync(tempFilePath).size);
+      const storagePath = `${uuidv4()}/${filename}`;
+
+      try {
+        const newFile = await firebaseFileService.createFile(
+          tempFilePath,
+          {
+            storagePath,
+            originalFileName: filename,
+            uploadedUserId,
+            sizeBytes,
+          },
+          mimetype,
+        );
+        return newFile;
+      } finally {
+        fs.unlinkSync(tempFilePath);
+      }
+    },
+  },
+};
+
+export default firebaseFileResolvers;

--- a/backend/typescript/graphql/resolvers/firebaseFileResolvers.ts
+++ b/backend/typescript/graphql/resolvers/firebaseFileResolvers.ts
@@ -50,7 +50,7 @@ const firebaseFileResolvers = {
       await writeFile(createReadStream(), tempFilePath);
 
       const sizeBytes = BigInt(fs.statSync(tempFilePath).size);
-      const storagePath = `${uuidv4()}/${filename}`;
+      const storagePath = `interview_notes/${uuidv4()}/${filename}`;
 
       try {
         const newFile = await firebaseFileService.createFile(

--- a/backend/typescript/graphql/resolvers/firebaseFileResolvers.ts
+++ b/backend/typescript/graphql/resolvers/firebaseFileResolvers.ts
@@ -47,11 +47,9 @@ const firebaseFileResolvers = {
         throw new Error(getFileTypeValidationError(mimetype));
       }
 
-      const sanitizedFilename = path.basename(filename);
-
       const uploadDir = "uploads";
       const fileUUID = uuidv4();
-      const tempFilePath = `${uploadDir}/${fileUUID}-${sanitizedFilename}`;
+      const tempFilePath = `${uploadDir}/${fileUUID}`;
 
       await writeFile(createReadStream(), tempFilePath);
 
@@ -64,14 +62,14 @@ const firebaseFileResolvers = {
         );
       }
 
-      const storagePath = `interview_notes/${fileUUID}/${sanitizedFilename}`;
+      const storagePath = `interview_notes/${fileUUID}`;
 
       try {
         const newFile = await firebaseFileService.createFile(
           tempFilePath,
           {
             storagePath,
-            originalFileName: sanitizedFilename,
+            originalFileName: fileUUID,
             uploadedUserId,
             sizeBytes,
           },

--- a/backend/typescript/graphql/resolvers/firebaseFileResolvers.ts
+++ b/backend/typescript/graphql/resolvers/firebaseFileResolvers.ts
@@ -1,4 +1,5 @@
 import fs from "fs";
+import path from "path";
 import { FileUpload } from "graphql-upload";
 /* eslint-disable-next-line import/no-extraneous-dependencies */
 import { ReadStream } from "fs-capacitor";
@@ -17,6 +18,8 @@ const fileStorageService = new FileStorageService(defaultBucket);
 const firebaseFileService: IFirebaseFileService = new FirebaseFileService(
   fileStorageService,
 );
+
+const MAX_FILE_SIZE_BYTES = 10 * 1024 * 1024; // 10 MB
 
 const writeFile = (readStream: ReadStream, filePath: string): Promise<void> => {
   return new Promise((resolve, reject) => {
@@ -44,20 +47,31 @@ const firebaseFileResolvers = {
         throw new Error(getFileTypeValidationError(mimetype));
       }
 
+      const sanitizedFilename = path.basename(filename);
+
       const uploadDir = "uploads";
-      const tempFilePath = `${uploadDir}/${filename}`;
+      const fileUUID = uuidv4();
+      const tempFilePath = `${uploadDir}/${fileUUID}-${sanitizedFilename}`;
 
       await writeFile(createReadStream(), tempFilePath);
 
       const sizeBytes = BigInt(fs.statSync(tempFilePath).size);
-      const storagePath = `interview_notes/${uuidv4()}/${filename}`;
+
+      if (sizeBytes > BigInt(MAX_FILE_SIZE_BYTES)) {
+        fs.unlinkSync(tempFilePath);
+        throw new Error(
+          `File size ${sizeBytes} bytes exceeds the maximum allowed size of ${MAX_FILE_SIZE_BYTES} bytes`,
+        );
+      }
+
+      const storagePath = `interview_notes/${fileUUID}/${sanitizedFilename}`;
 
       try {
         const newFile = await firebaseFileService.createFile(
           tempFilePath,
           {
             storagePath,
-            originalFileName: filename,
+            originalFileName: sanitizedFilename,
             uploadedUserId,
             sizeBytes,
           },

--- a/backend/typescript/graphql/types/entityType.ts
+++ b/backend/typescript/graphql/types/entityType.ts
@@ -8,8 +8,6 @@ const entityType = gql`
     D
   }
 
-  scalar Upload
-
   type EntityResponseDTO {
     id: ID!
     stringField: String!

--- a/backend/typescript/graphql/types/firebaseFileType.ts
+++ b/backend/typescript/graphql/types/firebaseFileType.ts
@@ -1,0 +1,21 @@
+import { gql } from "apollo-server-express";
+
+const firebaseFileType = gql`
+  scalar Upload
+
+  type FirebaseFileDTO {
+    id: String!
+    storagePath: String!
+    originalFileName: String!
+    uploadedUserId: Int!
+    sizeBytes: String!
+    createdAt: String!
+    updatedAt: String!
+  }
+
+  extend type Mutation {
+    createFirebaseFile(file: Upload!, uploadedUserId: Int!): FirebaseFileDTO!
+  }
+`;
+
+export default firebaseFileType;

--- a/backend/typescript/services/implementations/fileStorageService.ts
+++ b/backend/typescript/services/implementations/fileStorageService.ts
@@ -20,7 +20,7 @@ class FileStorageService implements IFileStorageService {
       expirationDate.getMinutes() + expirationTimeMinutes,
     );
     try {
-      const currentBlob = await bucket.file(fileName);
+      const currentBlob = bucket.file(fileName);
       if (!(await currentBlob.exists())[0]) {
         throw new Error(`File name ${fileName} does not exist`);
       }
@@ -44,7 +44,7 @@ class FileStorageService implements IFileStorageService {
   ): Promise<void> {
     try {
       const bucket = storage().bucket(this.bucketName);
-      const currentBlob = await bucket.file(fileName);
+      const currentBlob = bucket.file(fileName);
       if ((await currentBlob.exists())[0]) {
         throw new Error(`File name ${fileName} already exists`);
       }
@@ -65,7 +65,7 @@ class FileStorageService implements IFileStorageService {
   ): Promise<void> {
     try {
       const bucket = storage().bucket(this.bucketName);
-      const currentBlob = await bucket.file(fileName);
+      const currentBlob = bucket.file(fileName);
       if (!(await currentBlob.exists())[0]) {
         throw new Error(`File name ${fileName} does not exist`);
       }
@@ -82,8 +82,8 @@ class FileStorageService implements IFileStorageService {
   async deleteFile(fileName: string): Promise<void> {
     try {
       const bucket = storage().bucket(this.bucketName);
-      const currentBlob = await bucket.file(fileName);
-      if (!currentBlob) {
+      const currentBlob = bucket.file(fileName);
+      if (!(await currentBlob.exists())[0]) {
         throw new Error(`File name ${fileName} does not exist`);
       }
       await currentBlob.delete();

--- a/backend/typescript/services/implementations/firebaseFileService.ts
+++ b/backend/typescript/services/implementations/firebaseFileService.ts
@@ -1,0 +1,54 @@
+import File from "../../models/file.model";
+import IFileStorageService from "../interfaces/fileStorageService";
+import IFirebaseFileService from "../interfaces/firebaseFileService";
+import { CreateFirebaseFileDTO, FirebaseFileDTO } from "../../types";
+import { getErrorMessage } from "../../utilities/errorUtils";
+import logger from "../../utilities/logger";
+
+const Logger = logger(__filename);
+
+class FirebaseFileService implements IFirebaseFileService {
+  fileStorageService: IFileStorageService;
+
+  constructor(fileStorageService: IFileStorageService) {
+    this.fileStorageService = fileStorageService;
+  }
+
+  async createFile(
+    filePath: string,
+    fileDTO: CreateFirebaseFileDTO,
+    contentType: string,
+  ): Promise<FirebaseFileDTO> {
+    try {
+      await this.fileStorageService.createFile(
+        fileDTO.storagePath,
+        filePath,
+        contentType,
+      );
+
+      const file = await File.create({
+        storagePath: fileDTO.storagePath,
+        originalFileName: fileDTO.originalFileName,
+        uploadedUserId: fileDTO.uploadedUserId,
+        sizeBytes: fileDTO.sizeBytes,
+      });
+
+      return {
+        id: file.id,
+        storagePath: file.storagePath,
+        originalFileName: file.originalFileName,
+        uploadedUserId: file.uploadedUserId,
+        sizeBytes: file.sizeBytes,
+        createdAt: file.createdAt,
+        updatedAt: file.updatedAt,
+      };
+    } catch (error: unknown) {
+      Logger.error(
+        `Failed to create firebase file. Reason = ${getErrorMessage(error)}`,
+      );
+      throw error;
+    }
+  }
+}
+
+export default FirebaseFileService;

--- a/backend/typescript/services/interfaces/firebaseFileService.ts
+++ b/backend/typescript/services/interfaces/firebaseFileService.ts
@@ -1,0 +1,11 @@
+import { CreateFirebaseFileDTO, FirebaseFileDTO } from "../../types";
+
+interface IFirebaseFileService {
+  createFile(
+    filePath: string,
+    fileDTO: CreateFirebaseFileDTO,
+    contentType: string,
+  ): Promise<FirebaseFileDTO>;
+}
+
+export default IFirebaseFileService;


### PR DESCRIPTION
## Notion ticket link
<!-- Please replace with your ticket's URL -->
[Build file upload POC](https://www.notion.so/uwblueprintexecs/Build-PoC-for-File-Uploads-30a10f3fb1dc80ce8dd7e1585aef850a?source=copy_link)


<!-- Give a quick summary of the implementation details, provide design justifications if necessary -->
## Implementation description
- Added a new GraphQL mutation to upload files and return file metadata.
- Added 10 MB size limit, temp-file handling, and guaranteed cleanup.
- Added service-layer support to upload to Firebase Storage and persist file metadata.
- Fixed storage existence checks and removed duplicate Upload scalar definition.
- Updated ignore rules to keep temp uploads out of git.



<!-- What should the reviewer do to verify your changes? Describe expected results and include screenshots when appropriate -->
## Steps to test
1. follow instructions in frontend PR to test backend behaviour (https://github.com/uwblueprint/website-bp/pull/258)

note: you might need firebase credentials to test properly


<!-- Draw attention to the substantial parts of your PR or anything you'd like a second opinion on -->
## What should reviewers focus on?
- Upload validation and auth 
- Firebase upload plus DB metadata consistency

## Checklist
- [x] My PR name is descriptive and in imperative tense
- [x] My commit messages are descriptive and in imperative tense. My commits are atomic and trivial commits are squashed or fixup'd into non-trivial commits
- [x] I have run the appropriate linter(s)
- [ ] I have requested a review from the PL, as well as other devs who have background knowledge on this PR or who will be building on top of this PR
