### PR TITLE
[INTW26] Implement backend updates for interview scheduling feature

### DIFF
--- a/backend/typescript/graphql/index.ts
+++ b/backend/typescript/graphql/index.ts
@@ -31,6 +31,8 @@ import interviewDelegationsTypes from "./types/interviewDelegationsTypes";
 import interviewDelegationsResolvers from "./resolvers/interviewDelegationsResolvers";
 import interviewPageResolvers from "./resolvers/interviewPageResolvers";
 import interviewPageType from "./types/interviewPageTypes";
+import interviewGroupTypes from "./types/interviewGroupTypes";
+import interviewGroupResolvers from "./resolvers/interviewGroupResolvers";
 
 const query = gql`
   type Query {
@@ -61,6 +63,7 @@ const executableSchema = makeExecutableSchema({
     reviewedApplicantRecordTypes,
     interviewedApplicantRecordsTypes,
     interviewPageType,
+    interviewGroupTypes,
   ],
   resolvers: merge(
     authResolvers,
@@ -76,6 +79,7 @@ const executableSchema = makeExecutableSchema({
     reviewedApplicantRecordResolvers,
     interviewedApplicantRecordsResolvers,
     interviewPageResolvers,
+    interviewGroupResolvers,
   ),
 });
 
@@ -99,6 +103,8 @@ const graphQLMiddlewares = {
     getInterviewDelegation: authorizedByAllRoles(),
     getInterviewedApplicantsByUserId: authorizedByAllRoles(),
     getInterviewedPairingsByUserId: authorizedByAllRoles(),
+    getInterviewersByGroupId: authorizedByAllRoles(),
+    getInterviewGroupById: authorizedByAllRoles(),
   },
   Mutation: {
     createEntity: authorizedByAllRoles(),
@@ -127,6 +133,9 @@ const graphQLMiddlewares = {
     deleteInterviewDelegation: authorizedByAllRoles(),
     bulkCreateInterviewDelegations: authorizedByAllRoles(),
     bulkDeleteInterviewDelegations: authorizedByAllRoles(),
+    createInterviewGroup: authorizedByAllRoles(),
+    deleteInterviewGroupById: authorizedByAllRoles(),
+    updateInterviewGroup: authorizedByAllRoles(),
   },
 };
 

--- a/backend/typescript/graphql/resolvers/interviewGroupResolvers.ts
+++ b/backend/typescript/graphql/resolvers/interviewGroupResolvers.ts
@@ -1,0 +1,73 @@
+import InterviewGroupService from "../../services/implementations/interviewGroupService";
+import IInterviewGroupService from "../../services/interfaces/IInterviewGroupService";
+import {
+  CreateInterviewGroupDTO,
+  InterviewGroupDTO,
+  UpdateInterviewGroupDTO,
+} from "../../types";
+import { getErrorMessage } from "../../utilities/errorUtils";
+
+const interviewGroupService: IInterviewGroupService =
+  new InterviewGroupService();
+
+const interviewGroupResolvers = {
+  Query: {
+    getInterviewGroupById: async (
+      _parent: undefined,
+      args: { id: string },
+    ): Promise<InterviewGroupDTO> => {
+      try {
+        return await interviewGroupService.getInterviewGroupById(args.id);
+      } catch (error) {
+        throw new Error(getErrorMessage(error));
+      }
+    },
+  },
+
+  Mutation: {
+    createInterviewGroup: async (
+      _parent: undefined,
+      args: {
+        interviewGroup: CreateInterviewGroupDTO;
+      },
+    ): Promise<InterviewGroupDTO> => {
+      try {
+        return await interviewGroupService.createInterviewGroup(
+          args.interviewGroup,
+        );
+      } catch (error) {
+        throw new Error(getErrorMessage(error));
+      }
+    },
+
+    updateInterviewGroup: async (
+      _parent: undefined,
+      args: {
+        id: string;
+        interviewGroup: UpdateInterviewGroupDTO;
+      },
+    ): Promise<InterviewGroupDTO> => {
+      try {
+        return await interviewGroupService.updateInterviewGroup(
+          args.id,
+          args.interviewGroup,
+        );
+      } catch (error) {
+        throw new Error(getErrorMessage(error));
+      }
+    },
+
+    deleteInterviewGroupById: async (
+      _parent: undefined,
+      args: { id: string },
+    ): Promise<InterviewGroupDTO> => {
+      try {
+        return await interviewGroupService.deleteInterviewGroupById(args.id);
+      } catch (error) {
+        throw new Error(getErrorMessage(error));
+      }
+    },
+  },
+};
+
+export default interviewGroupResolvers;

--- a/backend/typescript/graphql/resolvers/interviewPageResolvers.ts
+++ b/backend/typescript/graphql/resolvers/interviewPageResolvers.ts
@@ -1,5 +1,9 @@
 import InterviewPageService from "../../services/implementations/interviewPageService";
-import { InterviewedApplicantsDTO, InterviewPairingsDTO } from "../../types";
+import {
+  InterviewedApplicantsDTO,
+  InterviewPairingsDTO,
+  UserDTO,
+} from "../../types";
 import { getErrorMessage } from "../../utilities/errorUtils";
 
 const interviewPageService = new InterviewPageService();
@@ -28,6 +32,17 @@ const interviewPageResolvers = {
         return await interviewPageService.getInterviewedPairingsByUserId(
           userId,
         );
+      } catch (error) {
+        throw new Error(getErrorMessage(error));
+      }
+    },
+    getInterviewersByGroupId: async (
+      _parent: undefined,
+      args: { groupId: string },
+    ): Promise<UserDTO[]> => {
+      const { groupId } = args;
+      try {
+        return await interviewPageService.getInterviewersByGroupId(groupId);
       } catch (error) {
         throw new Error(getErrorMessage(error));
       }

--- a/backend/typescript/graphql/types/authType.ts
+++ b/backend/typescript/graphql/types/authType.ts
@@ -8,6 +8,7 @@ const authType = gql`
     email: String!
     position: String
     role: Role!
+    profilePictureFileId: ID
     accessToken: String!
     refreshToken: String!
   }

--- a/backend/typescript/graphql/types/interviewGroupTypes.ts
+++ b/backend/typescript/graphql/types/interviewGroupTypes.ts
@@ -1,0 +1,38 @@
+import { gql } from "apollo-server-express";
+
+const interviewGroupTypes = gql`
+  type InterviewGroupDTO {
+    id: ID!
+    schedulingLink: String
+    status: String!
+  }
+
+  input CreateInterviewGroupDTO {
+    schedulingLink: String
+    status: String!
+  }
+
+  input UpdateInterviewGroupDTO {
+    schedulingLink: String
+    status: String!
+  }
+
+  extend type Query {
+    getInterviewGroupById(id: ID!): InterviewGroupDTO!
+  }
+
+  extend type Mutation {
+    createInterviewGroup(
+      interviewGroup: CreateInterviewGroupDTO!
+    ): InterviewGroupDTO!
+
+    updateInterviewGroup(
+      id: ID!
+      interviewGroup: UpdateInterviewGroupDTO!
+    ): InterviewGroupDTO!
+
+    deleteInterviewGroupById(id: ID!): InterviewGroupDTO!
+  }
+`;
+
+export default interviewGroupTypes;

--- a/backend/typescript/graphql/types/interviewPageTypes.ts
+++ b/backend/typescript/graphql/types/interviewPageTypes.ts
@@ -17,6 +17,7 @@ const interviewPageType = gql`
   extend type Query {
     getInterviewedApplicantsByUserId(userId: Int!): [InterviewedApplicantsDTO!]!
     getInterviewedPairingsByUserId(userId: Int!): [InterviewPairingsDTO!]!
+    getInterviewersByGroupId(groupId: ID!): [UserDTO!]!
   }
 `;
 

--- a/backend/typescript/graphql/types/userType.ts
+++ b/backend/typescript/graphql/types/userType.ts
@@ -13,6 +13,7 @@ const userType = gql`
     email: String!
     role: Role!
     position: String
+    profilePictureFileId: ID
   }
 
   input CreateUserDTO {

--- a/backend/typescript/migrations/20260510025107-add-pfp-to-user-as-firebase-file.ts
+++ b/backend/typescript/migrations/20260510025107-add-pfp-to-user-as-firebase-file.ts
@@ -1,0 +1,23 @@
+import { DataType } from "sequelize-typescript";
+import { Migration } from "../umzug";
+
+const TABLE_NAME = "users";
+
+export const up: Migration = async ({ context: sequelize }) => {
+  await sequelize
+    .getQueryInterface()
+    .addColumn(TABLE_NAME, "profilePictureFileId", {
+      type: DataType.UUID,
+      allowNull: true,
+      references: {
+        model: "firebase_files",
+        key: "id",
+      },
+    });
+};
+
+export const down: Migration = async ({ context: sequelize }) => {
+  await sequelize
+    .getQueryInterface()
+    .removeColumn(TABLE_NAME, "profilePictureFileId");
+};

--- a/backend/typescript/models/file.model.ts
+++ b/backend/typescript/models/file.model.ts
@@ -1,3 +1,4 @@
+/* eslint import/no-cycle: 0 */
 import {
   Column,
   DataType,

--- a/backend/typescript/models/interviewGroup.model.ts
+++ b/backend/typescript/models/interviewGroup.model.ts
@@ -5,7 +5,11 @@ import InterviewDelegation from "./interviewDelegation.model";
 
 @Table({ tableName: "interview_groups" })
 export default class InterviewGroup extends Model {
-  @Column({ type: DataType.UUIDV4, primaryKey: true })
+  @Column({
+    type: DataType.UUID,
+    primaryKey: true,
+    defaultValue: DataType.UUIDV4,
+  })
   id!: string;
 
   @Column({ type: DataType.STRING, allowNull: true, defaultValue: null })

--- a/backend/typescript/models/user.model.ts
+++ b/backend/typescript/models/user.model.ts
@@ -1,6 +1,7 @@
 /* eslint import/no-cycle: 0 */
 
 import {
+  BelongsTo,
   Column,
   DataType,
   ForeignKey,
@@ -10,6 +11,7 @@ import {
 } from "sequelize-typescript";
 import { NonAttribute } from "sequelize";
 import { Role } from "../types";
+import File from "./file.model";
 import Position from "./position.model";
 import ReviewedApplicantRecord from "./reviewedApplicantRecord.model";
 
@@ -39,6 +41,13 @@ export default class User extends Model {
 
   @Column({ type: DataType.BOOLEAN, defaultValue: true })
   isActive!: boolean;
+
+  @ForeignKey(() => File)
+  @Column({ type: DataType.UUID, allowNull: true })
+  profilePictureFileId?: string;
+
+  @BelongsTo(() => File, { foreignKey: "profilePictureFileId" })
+  profilePicture?: NonAttribute<File>;
 
   @HasMany(() => ReviewedApplicantRecord, {
     foreignKey: "reviewerId",

--- a/backend/typescript/services/implementations/interviewGroupService.ts
+++ b/backend/typescript/services/implementations/interviewGroupService.ts
@@ -1,0 +1,95 @@
+import InterviewGroup from "../../models/interviewGroup.model";
+import {
+  CreateInterviewGroupDTO,
+  InterviewGroupDTO,
+  UpdateInterviewGroupDTO,
+} from "../../types";
+import { getErrorMessage } from "../../utilities/errorUtils";
+import logger from "../../utilities/logger";
+import IInterviewGroupService from "../interfaces/IInterviewGroupService";
+
+const Logger = logger(__filename);
+
+function toInterviewGroupDTO(
+  interviewGroup: InterviewGroup,
+): InterviewGroupDTO {
+  return {
+    id: interviewGroup.id,
+    schedulingLink: interviewGroup.schedulingLink,
+    status: interviewGroup.status,
+  };
+}
+
+class InterviewGroupService implements IInterviewGroupService {
+  /* eslint-disable class-methods-use-this */
+  async getInterviewGroupById(id: string): Promise<InterviewGroupDTO> {
+    try {
+      const interviewGroup = await InterviewGroup.findByPk(id);
+      if (!interviewGroup) {
+        throw new Error(`No interview group found for id: ${id}`);
+      }
+      return toInterviewGroupDTO(interviewGroup);
+    } catch (error: unknown) {
+      Logger.error(
+        `Failed to fetch interview group. Reason = ${getErrorMessage(error)}`,
+      );
+      throw error;
+    }
+  }
+
+  async createInterviewGroup(
+    interviewGroup: CreateInterviewGroupDTO,
+  ): Promise<InterviewGroupDTO> {
+    try {
+      const { schedulingLink, status } = interviewGroup;
+      const newInterviewGroup = await InterviewGroup.create({
+        schedulingLink,
+        status,
+      });
+      return toInterviewGroupDTO(newInterviewGroup);
+    } catch (error: unknown) {
+      Logger.error(
+        `Failed to create interview group. Reason = ${getErrorMessage(error)}`,
+      );
+      throw error;
+    }
+  }
+
+  async updateInterviewGroup(
+    id: string,
+    interviewGroup: UpdateInterviewGroupDTO,
+  ): Promise<InterviewGroupDTO> {
+    try {
+      const existing = await InterviewGroup.findByPk(id);
+      if (!existing) {
+        throw new Error(`No interview group found for id: ${id}`);
+      }
+
+      await existing.update(interviewGroup);
+      return toInterviewGroupDTO(existing);
+    } catch (error: unknown) {
+      Logger.error(
+        `Failed to update interview group. Reason = ${getErrorMessage(error)}`,
+      );
+      throw error;
+    }
+  }
+
+  async deleteInterviewGroupById(id: string): Promise<InterviewGroupDTO> {
+    try {
+      const interviewGroup = await InterviewGroup.findByPk(id);
+      if (!interviewGroup) {
+        throw new Error(`No interview group found for id: ${id}`);
+      }
+      await interviewGroup.destroy();
+      return toInterviewGroupDTO(interviewGroup);
+    } catch (error: unknown) {
+      Logger.error(
+        `Failed to delete interview group. Reason = ${getErrorMessage(error)}`,
+      );
+      throw error;
+    }
+  }
+}
+
+export default InterviewGroupService;

--- a/backend/typescript/services/implementations/interviewPageService.ts
+++ b/backend/typescript/services/implementations/interviewPageService.ts
@@ -125,7 +125,9 @@ class InterviewPageService implements IInterviewPageService {
         },
       });
 
-      const interviewers = delegations.map((delegation) => delegation.interviewer);
+      const interviewers = delegations.map(
+        (delegation) => delegation.interviewer,
+      );
       if (interviewers.length === 0) {
         return [];
       }

--- a/backend/typescript/services/implementations/interviewPageService.ts
+++ b/backend/typescript/services/implementations/interviewPageService.ts
@@ -114,6 +114,41 @@ class InterviewPageService implements IInterviewPageService {
       throw error;
     }
   }
+
+  async getInterviewersByGroupId(groupId: string): Promise<UserDTO[]> {
+    try {
+      const delegations = await InterviewDelegation.findAll({
+        where: { groupId },
+        include: {
+          model: User,
+          as: "interviewer",
+        },
+      });
+
+      const interviewers = delegations.map((delegation) => delegation.interviewer);
+      if (interviewers.length === 0) {
+        return [];
+      }
+
+      const uniqueByInterviewerId = new Set<number>();
+      const uniqueInterviewers = interviewers.filter((interviewer) => {
+        if (uniqueByInterviewerId.has(interviewer.id)) {
+          return false;
+        }
+        uniqueByInterviewerId.add(interviewer.id);
+        return true;
+      });
+
+      return uniqueInterviewers.map((interviewer) => toUserDTO(interviewer));
+    } catch (error: unknown) {
+      Logger.error(
+        `Failed to get interview delegations by groupId. Reason = ${getErrorMessage(
+          error,
+        )}`,
+      );
+      throw error;
+    }
+  }
 }
 
 export default InterviewPageService;

--- a/backend/typescript/services/implementations/userService.ts
+++ b/backend/typescript/services/implementations/userService.ts
@@ -35,6 +35,7 @@ class UserService implements IUserService {
       email: "firebaseUser.email ?? ",
       position: user.position ?? undefined,
       role: user.role,
+      profilePictureFileId: user.profilePictureFileId ?? undefined,
     };
   }
 
@@ -63,6 +64,7 @@ class UserService implements IUserService {
       email: email ?? "",
       position: user.position ?? undefined,
       role: user.role,
+      profilePictureFileId: user.profilePictureFileId ?? undefined,
     };
   }
 
@@ -136,6 +138,7 @@ class UserService implements IUserService {
             email: firebaseUser.email ?? "",
             position: user.position ?? undefined,
             role: user.role,
+            profilePictureFileId: user.profilePictureFileId ?? undefined,
           };
         }),
       );

--- a/backend/typescript/services/interfaces/IInterviewGroupService.ts
+++ b/backend/typescript/services/interfaces/IInterviewGroupService.ts
@@ -1,0 +1,41 @@
+import {
+  CreateInterviewGroupDTO,
+  InterviewGroupDTO,
+  UpdateInterviewGroupDTO,
+} from "../../types";
+
+interface IInterviewGroupService {
+  /**
+   * Fetches a single interview group by id.
+   * @param id PK of the interview group
+   */
+  getInterviewGroupById(id: string): Promise<InterviewGroupDTO>;
+
+  /**
+   * Creates a new interview group.
+   * @param status initial status
+   * @param schedulingLink scheduling link, or undefined if not yet set
+   */
+  createInterviewGroup(
+    interviewGroup: CreateInterviewGroupDTO,
+  ): Promise<InterviewGroupDTO>;
+
+  /**
+   * Updates an existing interview group.
+   * @param id PK of the interview group to update
+   * @param status updated status
+   * @param schedulingLink updated scheduling link, or undefined to clear it
+   */
+  updateInterviewGroup(
+    id: string,
+    interviewGroup: UpdateInterviewGroupDTO,
+  ): Promise<InterviewGroupDTO>;
+
+  /**
+   * Deletes an interview group by id.
+   * @param id PK of the interview group to delete
+   */
+  deleteInterviewGroupById(id: string): Promise<InterviewGroupDTO>;
+}
+
+export default IInterviewGroupService;

--- a/backend/typescript/services/interfaces/IInterviewPageService.ts
+++ b/backend/typescript/services/interfaces/IInterviewPageService.ts
@@ -1,4 +1,8 @@
-import { InterviewedApplicantsDTO, InterviewPairingsDTO } from "../../types";
+import {
+  InterviewedApplicantsDTO,
+  InterviewPairingsDTO,
+  UserDTO,
+} from "../../types";
 
 interface IInterviewPageService {
   /**
@@ -16,6 +20,12 @@ interface IInterviewPageService {
   getInterviewedPairingsByUserId(
     userId: number,
   ): Promise<InterviewPairingsDTO[]>;
+
+  /**
+   * Returns distinct interviewers assigned to an interview group (by delegation rows).
+   * @param groupId the interview group id
+   */
+  getInterviewersByGroupId(groupId: string): Promise<UserDTO[]>;
 }
 
 export default IInterviewPageService;

--- a/backend/typescript/types.ts
+++ b/backend/typescript/types.ts
@@ -33,6 +33,7 @@ export type UserDTO = {
   email: string;
   position?: string;
   role: Role;
+  profilePictureFileId?: string;
 };
 
 export type ShortQuestionAnswerDTO = {
@@ -264,6 +265,12 @@ export type InterviewedApplicantRecordDTO = {
   interviewDate?: Date;
 };
 
+export type InterviewedApplicantDTO = {
+  applicantRecordId: string;
+  firstName: string;
+  lastName: string;
+};
+
 export type ReviewDetails = {
   reviewerFirstName: string;
   reviewerLastName: string;
@@ -363,3 +370,12 @@ export type DeleteInterviewDelegationDTO = {
   interviewedApplicantRecordId: string;
   interviewerId: number;
 };
+
+export type InterviewGroupDTO = {
+  id: string;
+  schedulingLink?: string;
+  status: InterviewGroupStatus;
+};
+
+export type CreateInterviewGroupDTO = Omit<InterviewGroupDTO, "id">;
+export type UpdateInterviewGroupDTO = Omit<InterviewGroupDTO, "id">;


### PR DESCRIPTION
THIS BRANCH IS CURRENTLY BASED OFF OF `INTW26-build-interview-delegation-algorithm`, REBASE ONTO MAIN ONCE #127 GETS MERGED

## Notion ticket link
<!-- Please replace with your ticket's URL -->
[Implement Interview Scheduling Feature](https://www.notion.so/uwblueprintexecs/Implement-Interview-Scheduling-Feature-32d10f3fb1dc808682addc6d6f285005?source=copy_link)


<!-- Give a quick summary of the implementation details, provide design justifications if necessary -->
## Implementation description
* In the model `User`, add a fk `profilePictureFileId` to `firebase_files`
* Define and implement new resolvers `getInterviewedApplicantsByGroupId` and `getInterviewersByGroupId` for the interview review page


<!-- What should the reviewer do to verify your changes? Describe expected results and include screenshots when appropriate -->
## Steps to test
1. `docker compose up` and `docker exec recruitment_tools_backend node migrate up`, ensure that the migrations ran successfully and in pgAdmin the `users` table now has a `profilePictureFileId` fk to `firebase_files`
2. Run the following sql queries separately and in order to create copies of each existing seeded applicant record
```sql
CREATE EXTENSION IF NOT EXISTS pgcrypto;
```
```sql
INSERT INTO public.interviewed_applicant_records (id, "applicantRecordId", status, "createdAt", "updatedAt")
SELECT
	gen_random_uuid(),
	id,
	'NeedsReview',
	NOW(),
	NOW()
FROM public.applicant_records
ON CONFLICT ("applicantRecordId") DO NOTHING;
```
3. Run the following sql query to create a bunch of dummy users with position "Developer"
```sql
INSERT INTO users (first_name, last_name, email, auth_id, role, position, "isActive")
VALUES
  ('Test', 'User1',  'testuser1@test.com',  'test_auth_1',  'User', 'Developer', true),
  ('Test', 'User2',  'testuser2@test.com',  'test_auth_2',  'User', 'Developer', true),
  ('Test', 'User3',  'testuser3@test.com',  'test_auth_3',  'User', 'Developer', true),
  ('Test', 'User4',  'testuser4@test.com',  'test_auth_4',  'User', 'Developer', true),
  ('Test', 'User5',  'testuser5@test.com',  'test_auth_5',  'User', 'Developer', true),
  ('Test', 'User6',  'testuser6@test.com',  'test_auth_6',  'User', 'Developer', true),
  ('Test', 'User7',  'testuser7@test.com',  'test_auth_7',  'User', 'Developer', true),
  ('Test', 'User8',  'testuser8@test.com',  'test_auth_8',  'User', 'Developer', true),
  ('Test', 'User9',  'testuser9@test.com',  'test_auth_9',  'User', 'Developer', true),
  ('Test', 'User10', 'testuser10@test.com', 'test_auth_10', 'User', 'Developer', true),
  ('Test', 'User11', 'testuser11@test.com', 'test_auth_11', 'User', 'Developer', true);
```
4. Run the following mutator, copy any one of the returned groupId in the response
```graphql
mutation DelegateInterviewers {
    delegateInterviewers(positions: ["Developer", "VP Engineering"]) {
        interviewedApplicantRecordId
        interviewerId
        interviewHasConflict
        groupId
    }
}
```
5. Call the following queries and confirm they work with the copied group id
```graphql
query GetInterviewedApplicantsByGroupId {
    getInterviewedApplicantsByGroupId(
        groupId: "<copied group id>"
    ) {
        applicantRecordId
        firstName
        lastName
    }
}
```
```graphql
query GetInterviewersByGroupId {
    getInterviewersByGroupId(groupId: "<copied group id>") {
        id
        firstName
        lastName
        email
        role
        position
        profilePictureFileId
    }
}
```


<!-- Draw attention to the substantial parts of your PR or anything you'd like a second opinion on -->
## What should reviewers focus on?
* Queries return error response for group ids with invalid uuid syntax


## Checklist
- [x] My PR name is descriptive and in imperative tense
- [x] My commit messages are descriptive and in imperative tense. My commits are atomic and trivial commits are squashed or fixup'd into non-trivial commits
- [x] I have run the appropriate linter(s)
- [x] I have requested a review from the PL, as well as other devs who have background knowledge on this PR or who will be building on top of this PR
